### PR TITLE
Resolves: Task 100088 - In ViewProcessStoryOutline, the document numbers should be unique

### DIFF
--- a/screen/coarchy/coapp.xml
+++ b/screen/coarchy/coapp.xml
@@ -60,6 +60,8 @@ along with this software (see the LICENSE.md file). If not, see
         html_scripts.add('/libs/moment.js/moment-with-locales.min.js')
         html_scripts.add('/libs/jquery/jquery.min.js')
 
+        html_stylesheets.add('/costatic/style.css')
+
         String instancePurpose = System.getProperty("instance_purpose")
         if (!instancePurpose || instancePurpose == 'production') {
             /* ========== Production Mode ========== */

--- a/screen/coarchy/costatic/style.css
+++ b/screen/coarchy/costatic/style.css
@@ -1,0 +1,19 @@
+/* hierarchial numbered list (1.1, 1.1.1, 1.1.1.1, etc..) */
+/* wrap ol tags with a <div class="numbered-list"></div> to activate */
+/* see https://stackoverflow.com/a/16270270 for more info */
+.numbered-list ol {
+  counter-reset: item;
+}
+
+.numbered-list li {
+  display: block;
+  position: relative;
+}
+
+.numbered-list li:before {
+  content: counters(item, ".") " ";
+  counter-increment: item;
+  position: absolute;
+  margin-right: 100%;
+  right: 10px; /* space between number and text */
+}

--- a/template/ProcessStoryOutline.html.ftl
+++ b/template/ProcessStoryOutline.html.ftl
@@ -1,3 +1,4 @@
+<div class="numbered-list">
 <ol>
 <#list processStoryActivityList! as processStoryActivity>
     <#if processStoryActivity.action!?has_content><li></#if><#include "ActivityStyledSpan.html.ftl"/><#if processStoryActivity.activity!?has_content></li></#if>
@@ -15,3 +16,4 @@
         </ol>
     </#if>
 </#macro>
+</div>


### PR DESCRIPTION
Changes: 
- Added style.css (screen/coarchy/costatic)
- Added style.css include statement in coapp.xml
- Added css classes to show ordered list numerical hierarchy. 
- Updated ProcessStoryOutline.qvt.ftl view to use these classes.