### PR TITLE
Resolves: 100099 - Fix organization month credit calculation

### DIFF
--- a/screen/coarchy/costatic/style.css
+++ b/screen/coarchy/costatic/style.css
@@ -5,6 +5,10 @@
   counter-reset: item;
 }
 
+.numbered-list ol > li:before {
+  content: counters(item, ".") ". ";
+}
+
 .numbered-list li {
   display: block;
   position: relative;

--- a/screen/settings/settingsinternal/Organizations.xml
+++ b/screen/settings/settingsinternal/Organizations.xml
@@ -287,22 +287,12 @@ along with this software (see the LICENSE.md file). If not, see
             <date-filter/>
             <order-by field-name="-transactionDate"/>
         </entity-find>
-
-        <set field="totalCreditsUsed" from="0.0" type="BigDecimal"/>
-        <entity-find entity-name="mantle.party.Party" list="otherOrganizationList">
-            <econdition field-name="partyTypeEnumId" value="PtyOrganization"/>
-            <econdition field-name="disabled" value="N" or-null="true"/>
-            <econdition field-name="ownerPartyId" from="ec.user.userAccount.partyId"/>
-            <select-field field-name="partyId"/>
-        </entity-find>
-        <set field="periodThruDate" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
-                (long) ec.user.nowTimestamp.time), ZoneId.systemDefault()).plusDays(1).truncatedTo(java.time.temporal.ChronoUnit.DAYS).toInstant().toEpochMilli())"/>
-        <set field="periodFromDate" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
-                (long) ec.user.nowTimestamp.time), ZoneId.systemDefault()).withDayOfMonth(1).truncatedTo(java.time.temporal.ChronoUnit.DAYS).toInstant().toEpochMilli())"/>
-        <iterate list="otherOrganizationList" entry="organization">
-            <service-call name="coarchy.CoarchyServices.calculate#PartyActivationUsage" in-map="[organizationPartyId:organization.partyId,periodFromDate:periodFromDate,periodThruDate:periodThruDate]" out-map="context"/>
-            <set field="totalCreditsUsed" from="totalCreditsUsed + activationPeriodCount" type="BigDecimal"/>
-        </iterate>
+        
+        <service-call name="mantle.party.PartyServices.get#PartyOrganizationInfo" out-map="context"/> 
+        <service-call name="coarchy.CoarchyServices.check#PartyActivation" 
+            in-map="[organizationPartyId: activeOrgId?:userOrgIds[0],finAccountTypeId:'OrganizationMonthCredit']" 
+            out-map="partyActivationOut" />
+        <set field="totalCreditsUsed" type="BigDecimal" from="partyActivationOut.totalCreditsUsed?:0.0" />
     </actions>
 
     <widgets>

--- a/screen/settings/settingsinternal/Organizations.xml
+++ b/screen/settings/settingsinternal/Organizations.xml
@@ -288,11 +288,12 @@ along with this software (see the LICENSE.md file). If not, see
             <order-by field-name="-transactionDate"/>
         </entity-find>
         
-        <service-call name="mantle.party.PartyServices.get#PartyOrganizationInfo" out-map="context"/> 
-        <service-call name="coarchy.CoarchyServices.check#PartyActivation" 
-            in-map="[organizationPartyId: activeOrgId?:userOrgIds[0],finAccountTypeId:'OrganizationMonthCredit']" 
-            out-map="partyActivationOut" />
-        <set field="totalCreditsUsed" type="BigDecimal" from="partyActivationOut.totalCreditsUsed?:0.0" />
+        <if condition="ec.user.userAccount?.partyId">
+            <service-call name="coarchy.CoarchyServices.check#PartyActivation" 
+                in-map="[userPartyId:ec.user.userAccount?.partyId, finAccountTypeId:'OrganizationMonthCredit']" 
+                out-map="partyActivationOut" />
+        </if>
+        <set field="totalCreditsUsed" type="BigDecimal" from="partyActivationOut?.totalCreditsUsed?:0.0" />
     </actions>
 
     <widgets>

--- a/screen/settings/settingsinternal/TransactionHistory.xml
+++ b/screen/settings/settingsinternal/TransactionHistory.xml
@@ -26,11 +26,12 @@ along with this software (see the LICENSE.md file). If not, see
             <order-by field-name="-transactionDate"/>
         </entity-find>
 
-        <service-call name="mantle.party.PartyServices.get#PartyOrganizationInfo" out-map="context"/> 
-        <service-call name="coarchy.CoarchyServices.check#PartyActivation" 
-            in-map="[organizationPartyId: activeOrgId?:userOrgIds[0],finAccountTypeId:'OrganizationMonthCredit']" 
-            out-map="partyActivationOut" />
-        <set field="totalCreditsUsed" type="BigDecimal" from="partyActivationOut.totalCreditsUsed?:0.0" />
+        <if condition="ec.user.userAccount?.partyId">
+            <service-call name="coarchy.CoarchyServices.check#PartyActivation" 
+                in-map="[userPartyId:ec.user.userAccount?.partyId, finAccountTypeId:'OrganizationMonthCredit']" 
+                out-map="partyActivationOut" />
+        </if>
+        <set field="totalCreditsUsed" type="BigDecimal" from="partyActivationOut?.totalCreditsUsed?:0.0" />
     </actions>
 
     <widgets>

--- a/screen/settings/settingsinternal/TransactionHistory.xml
+++ b/screen/settings/settingsinternal/TransactionHistory.xml
@@ -26,21 +26,11 @@ along with this software (see the LICENSE.md file). If not, see
             <order-by field-name="-transactionDate"/>
         </entity-find>
 
-        <set field="totalCreditsUsed" from="0.0" type="BigDecimal"/>
-        <entity-find entity-name="mantle.party.Party" list="otherOrganizationList">
-            <econdition field-name="partyTypeEnumId" value="PtyOrganization"/>
-            <econdition field-name="disabled" value="N" or-null="true"/>
-            <econdition field-name="ownerPartyId" from="ec.user.userAccount.partyId"/>
-            <select-field field-name="partyId"/>
-        </entity-find>
-        <set field="periodThruDate" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
-                (long) ec.user.nowTimestamp.time), ZoneId.systemDefault()).plusDays(1).truncatedTo(java.time.temporal.ChronoUnit.DAYS).toInstant().toEpochMilli())"/>
-        <set field="periodFromDate" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
-                (long) ec.user.nowTimestamp.time), ZoneId.systemDefault()).withDayOfMonth(1).truncatedTo(java.time.temporal.ChronoUnit.DAYS).toInstant().toEpochMilli())"/>
-        <iterate list="otherOrganizationList" entry="organization">
-            <service-call name="coarchy.CoarchyServices.calculate#PartyActivationUsage" in-map="[organizationPartyId:organization.partyId,periodFromDate:periodFromDate,periodThruDate:periodThruDate]" out-map="context"/>
-            <set field="totalCreditsUsed" from="totalCreditsUsed + activationPeriodCount" type="BigDecimal"/>
-        </iterate>
+        <service-call name="mantle.party.PartyServices.get#PartyOrganizationInfo" out-map="context"/> 
+        <service-call name="coarchy.CoarchyServices.check#PartyActivation" 
+            in-map="[organizationPartyId: activeOrgId?:userOrgIds[0],finAccountTypeId:'OrganizationMonthCredit']" 
+            out-map="partyActivationOut" />
+        <set field="totalCreditsUsed" type="BigDecimal" from="partyActivationOut.totalCreditsUsed?:0.0" />
     </actions>
 
     <widgets>

--- a/service/coarchy/CoarchyServices.xml
+++ b/service/coarchy/CoarchyServices.xml
@@ -1129,8 +1129,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <date-filter/></entity-find>
 
             <if condition="partyActivationList.size() == 0"><then>
-                <service-call name="coarchy.CoarchyServices.check#PartyActivation" in-map="[organizationPartyId:
-                    organizationPartyId,finAccountTypeId:'OrganizationMonthCredit']" out-map="context"/>
+                <service-call name="coarchy.CoarchyServices.check#PartyActivation" in-map="[userPartyId:ec.user.userAccount?.partyId, finAccountTypeId:'OrganizationMonthCredit']" out-map="context"/>
                 <if condition="needsCredits"><then>
                     <return type="warning" public="true"
                             message="Can't activate organization. Buy at least ${creditsNeeded} Organization-Month Credits to get premium"/>
@@ -1319,7 +1318,7 @@ along with this software (see the LICENSE.md file). If not, see
     </service>
     <service verb="check" noun="PartyActivation" authenticate="anonymous-all">
         <in-parameters>
-            <parameter name="organizationPartyId" required="true"/>
+            <parameter name="userPartyId" required="true"/>
             <parameter name="finAccountTypeId" required="true" default-value="OrganizationMonthCredit"/>
             <parameter name="currentTimestamp" default="ec.user.nowTimestamp" type="Timestamp" required="true"/>
         </in-parameters>
@@ -1340,11 +1339,14 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="periodThruDate" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
                 (long) currentTimestamp.time), ZoneId.systemDefault()).plusMonths(1).withDayOfMonth(1).toInstant().toEpochMilli())"/>
 
-            <entity-find-one entity-name="mantle.party.Party" value-field="organization" auto-field-map="[partyId:organizationPartyId]"/>
-            <if condition="!organization"><return type="warning" message="No organization found for ${organizationPartyId}"/></if>
+            <!-- check party exists -->
+            <entity-find-one entity-name="mantle.party.Party" value-field="userParty">
+                <field-map field-name="partyId" from="userPartyId" />
+            </entity-find-one>
+            <if condition="!userPartyId"><return type="warning" message="Party ${userParty} was not found"/></if>
 
             <entity-find entity-name="mantle.account.financial.FinancialAccount" list="financialAccountList" distinct="true">
-                <econdition field-name="ownerPartyId" from="organization.ownerPartyId"/>
+                <econdition field-name="ownerPartyId" from="userPartyId"/>
                 <econdition field-name="finAccountTypeId"/>
                 <econdition field-name="statusId" value="FaActive"/>
                 <date-filter valid-date="currentTimestamp"/>
@@ -1365,7 +1367,7 @@ along with this software (see the LICENSE.md file). If not, see
             <entity-find entity-name="mantle.party.Party" list="organizationList">
                 <econdition field-name="partyTypeEnumId" value="PtyOrganization"/>
                 <econdition field-name="disabled" value="N" or-null="true"/>
-                <econdition field-name="ownerPartyId" from="organization.ownerPartyId"/>
+                <econdition field-name="ownerPartyId" from="userPartyId"/>
             </entity-find>
             <if condition="organizationList.size() == 0">
                 <set field="needsCredits" from="true"/>

--- a/template/ProcessStoryOutline.html.ftl
+++ b/template/ProcessStoryOutline.html.ftl
@@ -1,10 +1,12 @@
 <div class="numbered-list">
 <ol>
 <#list processStoryActivityList! as processStoryActivity>
-    <#if processStoryActivity.action!?has_content><li></#if><#include "ActivityStyledSpan.html.ftl"/><#if processStoryActivity.activity!?has_content></li></#if>
+    <#if processStoryActivity.action!?has_content><li></#if>
+    <#include "ActivityStyledSpan.html.ftl"/>
     <#if processStoryActivity.detailProcessStoryId!?has_content && showSubstoriesActual>
         <@substory processStoryActivity 1/>
     </#if>
+    <#if processStoryActivity.activity!?has_content></li></#if>
     <#if !processStoryActivity.detailProcessStoryId!?has_content><br/></#if>
 </#list>
 </ol>
@@ -12,7 +14,9 @@
 <#macro substory processStoryActivity levels>
     <#if processStoryActivity.detailProcessStoryActivityList!?size == 0><#list 1..(levels+1) as level>&nbsp;&nbsp;</#list>No Activities<#else>
         <ol>
-        <#list processStoryActivity.detailProcessStoryActivityList! as processStoryActivity><li><#include "ActivityStyledSpan.html.ftl"/></li><#if processStoryActivity.detailProcessStoryId!?has_content><@substory processStoryActivity levels+1/></#if></#list>
+        <#list processStoryActivity.detailProcessStoryActivityList! as processStoryActivity>
+            <li><#include "ActivityStyledSpan.html.ftl"/><#if processStoryActivity.detailProcessStoryId!?has_content><@substory processStoryActivity levels+1/></#if></li>
+        </#list>
         </ol>
     </#if>
 </#macro>

--- a/template/ProcessStoryOutline.html.ftl
+++ b/template/ProcessStoryOutline.html.ftl
@@ -1,3 +1,13 @@
+<#macro substory processStoryActivity levels>
+    <#if processStoryActivity.detailProcessStoryActivityList!?size == 0><#list 1..(levels+1) as level>&nbsp;&nbsp;</#list>No Activities<br/><#else>
+        <ol>
+        <#list processStoryActivity.detailProcessStoryActivityList! as processStoryActivity>
+            <li><#include "ActivityStyledSpan.html.ftl"/><#if processStoryActivity.detailProcessStoryId!?has_content><@substory processStoryActivity levels+1/></#if></li>
+        </#list>
+        </ol>
+    </#if>
+</#macro>
+
 <div class="numbered-list">
 <ol>
 <#list processStoryActivityList! as processStoryActivity>
@@ -10,14 +20,4 @@
     <#if !processStoryActivity.detailProcessStoryId!?has_content><br/></#if>
 </#list>
 </ol>
-
-<#macro substory processStoryActivity levels>
-    <#if processStoryActivity.detailProcessStoryActivityList!?size == 0><#list 1..(levels+1) as level>&nbsp;&nbsp;</#list>No Activities<#else>
-        <ol>
-        <#list processStoryActivity.detailProcessStoryActivityList! as processStoryActivity>
-            <li><#include "ActivityStyledSpan.html.ftl"/><#if processStoryActivity.detailProcessStoryId!?has_content><@substory processStoryActivity levels+1/></#if></li>
-        </#list>
-        </ol>
-    </#if>
-</#macro>
 </div>


### PR DESCRIPTION
In Organization.xml & TransactionHistory.xml, used check#PartyActivation to calculate used credits. 

@acetousk , I  used one of [activeOrgId or the first entry in userOrgIds] to call check#PartyActivation. Looking at the logic in check#PartyActivation, it shouldn't matter because it looks at all orgs with the same ownerPartyId, but wanted to run it by you first.

Let me know if I missed anything.