### PR TITLE
Resolves CoarchyP-100044: In EditProcessStory screen, only one actor can be selected to insert a new activity

### DIFF
--- a/screen/coarchy/cointernal/Process/EditProcessStory/InsertActivity.xml
+++ b/screen/coarchy/cointernal/Process/EditProcessStory/InsertActivity.xml
@@ -24,7 +24,7 @@ along with this software (see the LICENSE.md file). If not, see
 
     <transition name="insertActivity">
         <service-call name="coarchy.CoarchyServices.insert#Activity" in-map="context + [organizationId:activeOrgId]"/>
-        <default-response url=".." parameter-map="[pageIndex:pageIndex]"/><error-response type="none"/></transition>
+        <default-response url=".." parameter-map="[pageIndex:pageIndex]"/></transition>
 
     <transition name="insertParagraphBreak"><actions>
         <set field="insertSequenceNum" from="sequenceNum"/>

--- a/service/coarchy/CoarchyServices.xml
+++ b/service/coarchy/CoarchyServices.xml
@@ -709,7 +709,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="action"/>
             <parameter name="sequenceNum"/>
             <parameter name="implementationId"/>
-            <parameter name="ignoreNoAction" default="false"/>
+            <parameter name="ignoreNoAction" type="Boolean" default="false"/>
         </in-parameters>
         <out-parameters>
             <parameter name="activityId"/>
@@ -2484,8 +2484,8 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="sequenceNum"/>
             <parameter name="implementationId"/>
             <parameter name="condition"/>
-            <parameter name="actorIdList"/>
-            <parameter name="action"/>
+            <parameter name="actorIdList" type="List"/>
+            <parameter name="action" type="String"/>
             <parameter name="insertType"/>
             <parameter name="organizationId"/>
             <parameter name="sequenceNumDiff" default="1" type="Integer"/>
@@ -2496,7 +2496,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="orderByField"/>
         </out-parameters>
         <actions>
-            <if condition="!action"><return type="danger" error="true" message="${ec.resource.expand('CoarchyProcessActivityActionRequired',null)}"/></if>
+            <if condition="!action?.trim()"><return type="danger" error="true" message="${ec.resource.expand('CoarchyProcessActivityActionRequired',null)}"/></if>
             <set field="insertSequenceNum" from="sequenceNum"/>
             <if condition="insertType=='below'">
                 <set field="pageIndex" from="downPageIndex"/>


### PR DESCRIPTION
Changelog:

- In create#Activity, set ignoreNoAction param type as boolean to return error if action is not provided. In insert#Activity, fix actorIdList not being properly handled due to incorrect type.
- In insertActivity transition, remove error-reponse type="none" to show error to user

NOTE: This pull request fixes error handling for when no action is provided in the AddActivity and InsertActivity dialogs.