### PR TITLE
Resolves CoarchyP-100055: Make ChangePassword resetPassword problem

### DIFF
--- a/data/CoarchyL10nData.xml
+++ b/data/CoarchyL10nData.xml
@@ -47,5 +47,8 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.LocalizedMessage locale="default" original="CoarchyProcessClipboardActivityEmpty" localized="Your clipboard contains no activities."/>
     <moqui.basic.LocalizedMessage locale="default" original="CoarchyProcessClipboardPasteError" localized="Something went wrong while pasting this activity."/>
     <moqui.basic.LocalizedMessage locale="default" original="CoarchyProcessActivityValueDeleteError" localized="Something went wrong while deleting value."/>
+    
+    <moqui.basic.LocalizedMessage locale="default" original="CoarchyAuthUserNotFound" localized="Invalid username or password."/>
+    <moqui.basic.LocalizedMessage locale="default" original="CoarchyAuthPasswordAlreadySet" localized="You have already set a password on this account. Please log in instead."/>
    
 </entity-facade-xml>

--- a/screen/coarchy-com/c/ChangePassword.xml
+++ b/screen/coarchy-com/c/ChangePassword.xml
@@ -20,6 +20,10 @@ along with this software (see the LICENSE.md file). If not, see
         <service-call name="coarchy.CoarchyServices.change#UserPassword" in-map="context"/>
         <default-response url="/settings"/><error-response url="." save-parameters="true"/>
     </transition>
+    <transition name="completeSignup">
+        <service-call name="coarchy.CoarchyServices.complete#UserSignup" in-map="context"/>
+        <default-response url="/settings"/><error-response url="." save-parameters="true"/>
+    </transition>
 
     <pre-actions><script>
         // if user already logged in redirect to application

--- a/screen/coarchy-com/cstatic/CoarchyComVue.qvt.js
+++ b/screen/coarchy-com/cstatic/CoarchyComVue.qvt.js
@@ -123,7 +123,7 @@ Vue.component('c-change-password', {
         '    <q-input filled v-model="username" :disable="this.cameFromEmail" :readonly="this.cameFromEmail" type="email" label="Work Email" :rules="[ val => val && val.length > 0 || \'Please type something\' ]"/>\n' +
         '    <q-input v-if="this.cameFromEmail" filled v-model="firstName" label="First Name" :rules="[ val => val && val.length > 0 || \'Please type something\']"/>\n' +
         '    <q-input v-if="this.cameFromEmail" filled v-model="lastName" label="Last Name" :rules="[ val => val && val.length > 0 || \'Please type something\']"/>\n' +
-        '    <q-input filled v-model="oldPassword" :readonly="this.cameFromEmail" label="Reset Password" :type="isOldPwd ? \'password\' : \'text\'" :rules="[ val => val && val.length > 0 || \'Please type something\']">' +
+        '    <q-input v-if="!this.cameFromEmail" filled v-model="oldPassword" :label="this.cameFromEmail?\'Reset Password\':\'Old Password\'" :type="isOldPwd ? \'password\' : \'text\'" :rules="[ val => val && val.length > 0 || \'Please type something\']">' +
         '        <template v-slot:append>\n' +
         '            <q-icon :name="isOldPwd ? \'visibility_off\' : \'visibility\'" class="cursor-pointer" @click="isOldPwd = !isOldPwd"/>\n' +
         '        </template>\n' +
@@ -139,11 +139,12 @@ Vue.component('c-change-password', {
         '      <template v-else-if="index === agreementlist.length - 2">, and&nbsp;</template>' +
         '   </template></p>' +
         '    <div>\n' +
-        '        <q-btn label="Create Account" type="submit" color="primary"/>\n' +
+        '        <q-btn :label="isCompleteSignup?\'Create Account\':\'Update\'" type="submit" color="primary"/>\n' +
         '    </div>\n' +
         '</q-form>',
     data () {
         return {
+            isCompleteSignup: false,
             username: null,
             cameFromEmail: false,
             firstName: null,
@@ -153,7 +154,6 @@ Vue.component('c-change-password', {
             isOldPwd: true,
             isNewPwd: true,
             agreementlist: null
-
         }
     },
     methods: {
@@ -177,7 +177,8 @@ Vue.component('c-change-password', {
             return response.json();
         },
         onSubmit () {
-            this.moqui.webrootVue.postData('/c/ChangePassword/changePassword', new URLSearchParams(this._data).toString())
+            const url = this.isCompleteSignup ? '/c/ChangePassword/completeSignup' : '/c/ChangePassword/changePassword'
+            this.moqui.webrootVue.postData(url, new URLSearchParams({...this._data, oldPassword:this.cameFromEmail ? this.oldPassword :this._data?.oldPassword}).toString())
                 .then((data) => {
                     this.moqui.webrootVue.handleNotificationOther(data)
                     const paths = window.location.href.split("/").filter(entry => entry !== "")
@@ -185,13 +186,14 @@ Vue.component('c-change-password', {
                         // redirect https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#javascript_redirections
                         window.location = data.screenUrl;
                     }
-                })
+                }).
         },
     },
     mounted: function() {
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.get('username')) this.username = urlParams.get('username')
         if (urlParams.get('oldPassword')) this.oldPassword = urlParams.get('oldPassword')
+        if (urlParams.get('action')) this.isCompleteSignup = urlParams.get('action') === 'signup' ? true : false
         if (this.username && this.oldPassword) this.cameFromEmail = true
 
         this.getData("/c/SignUp/actions").then((response) => {

--- a/screen/coarchy-com/cstatic/CoarchyComVue.qvt.js
+++ b/screen/coarchy-com/cstatic/CoarchyComVue.qvt.js
@@ -139,7 +139,7 @@ Vue.component('c-change-password', {
         '      <template v-else-if="index === agreementlist.length - 2">, and&nbsp;</template>' +
         '   </template></p>' +
         '    <div>\n' +
-        '        <q-btn :label="isCompleteSignup?\'Create Account\':\'Update\'" type="submit" color="primary"/>\n' +
+        '        <q-btn :label="isCompleteSignup?\'Create Account\':\'Update Password\'" type="submit" color="primary"/>\n' +
         '    </div>\n' +
         '</q-form>',
     data () {

--- a/service/coarchy/CoarchyServices.xml
+++ b/service/coarchy/CoarchyServices.xml
@@ -425,7 +425,7 @@ along with this software (see the LICENSE.md file). If not, see
                         <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
                             contactListId:'CoarchyInvitation',emailTemplateId:'USER_INVITE_RESET_PASSWORD',
                             partyId:newPartyId,preferredContactMechId:newUser.emailContactMechId,toAddresses:emailAddress,
-                            bodyParameters:[linkUrl:baseLinkUrl+'/ChangePassword?username='+emailAddress+'&amp;oldPassword='+resetPassword,
+                            bodyParameters:[linkUrl:baseLinkUrl+'/ChangePassword?username='+emailAddress+'&amp;oldPassword='+resetPassword+'&amp;action=signup',
                             title:'You\'re invited to join the '+organization.organizationName+' Organization',baseLinkUrl:baseLinkUrl]]" out-map="context"/>
                     </then>
                     <else-if condition="existingUaList &amp;&amp; !isInvitedUserOrgMember">
@@ -529,7 +529,25 @@ along with this software (see the LICENSE.md file). If not, see
             </else></if>
         </actions>
     </service>
+
     <service verb="change" noun="UserPassword">
+        <in-parameters>
+            <parameter name="username" required="true" default="ec.web?.sessionAttributes?.moquiPreAuthcUsername ?: username"/>
+            <parameter name="oldPassword" required="true"/>
+            <parameter name="newPassword" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="updateSuccessful"/>
+            <parameter name="loginSuccess"/>
+            <parameter name="passwordIssues"/>
+        </out-parameters>
+        <actions>
+            <service-call name="org.moqui.impl.UserServices.update#Password" in-map="[username:username,
+                oldPassword:oldPassword,newPassword:newPassword,newPasswordVerify:newPassword]" out-map="context"/>
+        </actions>
+    </service>
+
+    <service verb="complete" noun="UserSignup">
         <in-parameters>
             <parameter name="username" required="true" default="ec.web?.sessionAttributes?.moquiPreAuthcUsername ?: username"/>
             <parameter name="firstName" required="true"/>
@@ -543,6 +561,16 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="passwordIssues"/>
         </out-parameters>
         <actions>
+            <!-- make sure account exists and password has not been already been set by user -->
+            <entity-find-one entity-name="moqui.security.UserAccount" value-field="userAccount">
+                <field-map field-name="username" from="username" />
+                <select-field field-name="userId,partyId,currentPassword,passwordSetDate" />
+            </entity-find-one>
+            <if condition="!userAccount"><return error="true" message="${ec.resource.expand('CoarchyAuthUserNotFound','')}"/></if>
+            <if condition="userAccount.currentPassword &amp;&amp; userAccount.passwordSetDate">
+                <return error="true" message="${ec.resource.expand('CoarchyAuthPasswordAlreadySet','')}"/>
+            </if>
+
             <service-call name="org.moqui.impl.UserServices.update#Password" in-map="[username:username,
                 oldPassword:oldPassword,newPassword:newPassword,newPasswordVerify:newPassword]" out-map="context"/>
 
@@ -567,6 +595,7 @@ along with this software (see the LICENSE.md file). If not, see
             </if>
         </actions>
     </service>
+
     <service verb="create" noun="Account">
         <description>
             Create a basic user account including:


### PR DESCRIPTION
After some thinking, I thought it would be best to do some quick restructuring to how we approach this:

We're using one component (c-change-password) to handle three cases (not all are currently accessible by the user, but will be in the future):
1. User changing his current password (User knows old password)
2. User changing his current password after requesting reset (User is redirected from an email message, containing his reset password)
3. User setting his password for the first time after invitation

Currently, all these cases are expected to be handled in the Change#UserPassword service.

I suggest we split the service into two:
1. change#UserPassword
2. complete#UserSignup

This is to prevent an already signed up user from using the same link to sign up twice (his first/last names get overridden), plus separation of concerns.

I've also added a URL parameter called action: if action='signup', to help determine whether we should call completeSignup or changePassword. The parameter's value also determines the action button's text ( 'Create Account' or 'Update Password')

---
Also to fix the original problem, I've updated the m-change-password component to directly pass through the old password if the user came directly from an e-mail. Thus, we don't have to worry about form-data being changed by any browser. 

---

All in all, this paves the way for us to implement a change password screen for logged out users as well as a screen for a logged-in user to change his password.
