### PR TITLE
Resolves CoarchyP-100066: Refactor daily emails

### DIFF
--- a/data/CoarchyAaaSetupData.xml
+++ b/data/CoarchyAaaSetupData.xml
@@ -250,6 +250,10 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.service.job.ServiceJob jobName="update_SalesJourneyClassification" description="Update Sales Journey Classification"
             serviceName="coarchy.CoarchyServices.update#SalesJourneyClassification" cronExpression="0 0 3 * * ?" paused="N"
             transactionTimeout="3600"/>
+
+    <moqui.service.job.ServiceJob jobName="send_DailyEmails" description="Send Daily Emails"
+            serviceName="coarchy.CoarchyServices.send#DailyEmails" cronExpression="0 0 10 * * ?" paused="Y"
+            transactionTimeout="3600"/>
     <moqui.service.job.ServiceJob jobName="send_InvitationEmails__daily" description="Send Daily Invitation Emails"
             serviceName="coarchy.CoarchyServices.send#InvitationEmails" cronExpression="0 0 10 * * ?" paused="N"
             transactionTimeout="3600"/>

--- a/data/CoarchyAaaSetupData.xml
+++ b/data/CoarchyAaaSetupData.xml
@@ -250,8 +250,14 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.service.job.ServiceJob jobName="update_SalesJourneyClassification" description="Update Sales Journey Classification"
             serviceName="coarchy.CoarchyServices.update#SalesJourneyClassification" cronExpression="0 0 3 * * ?" paused="N"
             transactionTimeout="3600"/>
-    <moqui.service.job.ServiceJob jobName="send_DailyEmails" description="Send Daily Emails"
-            serviceName="coarchy.CoarchyServices.send#DailyEmails" cronExpression="0 0 10 * * ?" paused="N"
+    <moqui.service.job.ServiceJob jobName="send_InvitationEmails__daily" description="Send Daily Invitation Emails"
+            serviceName="coarchy.CoarchyServices.send#InvitationEmails" cronExpression="0 0 10 * * ?" paused="N"
+            transactionTimeout="3600"/>
+    <moqui.service.job.ServiceJob jobName="send_NewsletterEmails__daily" description="Send Daily Newsletter Emails"
+            serviceName="coarchy.CoarchyServices.send#NewsletterEmails" cronExpression="0 0 10 * * ?" paused="N"
+            transactionTimeout="3600"/>
+    <moqui.service.job.ServiceJob jobName="send_OnboardingEmails__daily" description="Send Daily Onboarding Emails"
+            serviceName="coarchy.CoarchyServices.send#OnboardingEmails" cronExpression="0 0 10 * * ?" paused="N"
             transactionTimeout="3600"/>
 
     <!-- ========== Agreements ========== -->

--- a/service/coarchy/CoarchyServices.xml
+++ b/service/coarchy/CoarchyServices.xml
@@ -3005,15 +3005,222 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
-    <service verb="send" noun="DailyEmails" authenticate="anonymous-all">
+    <service verb="send" noun="InvitationEmails" authenticate="anonymous-all">
+        <in-parameters>
+            <parameter name="currentTimestamp" default="ec.user.nowTimestamp" type="Timestamp" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="emailsSentList" type="List"/>
+            <parameter name="invitationPartyIdList" type="List"/>
+        </out-parameters>
+        <actions>
+            <set field="emailsSentList" from="[]"/>
+            <set field="baseLinkUrl" from="!'production'.equals(System.getProperty('instance_purpose')) ? 'http://localhost:8080' : 'https://coarchy.com'"/>
+
+            <set field="twoDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(2).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="fourDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(4).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="sixDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(6).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="eightDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(8).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="twoWeeksAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusWeeks(2).toInstant().toEpochMilli())" type="Timestamp"/>
+           
+            <entity-find entity-name="mantle.marketing.contact.ContactListParty" list="invitationPartyList">
+                <econdition field-name="contactListId" value="CoarchyInvitation"/>
+                <econdition field-name="statusId" value="CLPT_IN_USE"/>
+                <date-filter/></entity-find>
+            <set field="invitationPartyIdList" from="invitationPartyList*.partyId"/>
+
+            <iterate list="invitationPartyList" entry="listParty">
+                <!-- check when first invitiation email has was sent -->
+                <entity-find entity-name="mantle.marketing.contact.ContactListCommStatus" list="commStatusList">
+                    <econdition field-name="partyId" from="listParty.partyId"/>
+                    <econdition field-name="contactListId" from="listParty.contactListId"/>
+                    <order-by field-name="-lastUpdatedStamp"/></entity-find>
+                <set field="invitationList" from="[]"/>
+                <iterate list="commStatusList" entry="commStatus">
+                    <entity-find-one entity-name="mantle.party.communication.CommunicationEvent" value-field="communicationEvent"
+                            auto-field-map="[communicationEventId:commStatus.communicationEventId]">
+                        <select-field field-name="emailMessageId,entryDate"/>
+                    </entity-find-one>
+                    <entity-find-one entity-name="moqui.basic.email.EmailMessage" value-field="emailMessage"
+                            auto-field-map="[emailMessageId:communicationEvent.emailMessageId]">
+                        <select-field field-name="emailTemplateId,subject"/>
+                    </entity-find-one>
+                    <if condition="['USER_INVITE_RESET_PASSWORD','USER_INVITE'].contains(emailMessage?.emailTemplateId)">
+                        <set field="invitationDate" from="communicationEvent.entryDate"/>
+                        <set field="emailTemplateId" from="emailMessage.emailTemplateId"/>
+                        <set field="invitationList" from="invitationList + [invitationDate:invitationDate,
+                            emailTemplateId:emailTemplateId,subject:emailMessage.subject]"/>
+                    </if>
+                </iterate>
+
+                <!-- Just assume one user per party -->
+                <entity-find entity-name="moqui.security.UserAccount" list="userAccountList" limit="2" for-update="true">
+                    <econdition field-name="partyId" from="listParty.partyId"/>
+                    <econdition field-name="disabled" operator="not-equals" value="Y"/>
+                </entity-find>
+                <if condition="userAccountList.size() &gt; 1">
+                    <log level="warn" message="Multiple user accounts found for party ${listParty.partyId}"/>
+                </if>
+                <set field="userAccount" from="userAccountList?.getFirst()"/>
+
+                <entity-find entity-name="moqui.security.UserLoginHistory" list="historyList" limit="1">
+                    <econdition field-name="userId" from="userAccount.userId"/>
+                    <order-by field-name="fromDate"/></entity-find>
+
+                <set field="invitation" from="invitationList.max{ it.invitationDate }"/>
+                <set field="invitationDate" from="invitation?.invitationDate"/>
+
+                <if condition="invitationList.size() &lt; 3 &amp;&amp; userAccount &amp;&amp;
+                     twoDaysAgo.toInstant() &gt; invitationDate?.toInstant() &amp;&amp;
+                    (historyList.size() == 0 || (historyList.size() &gt; 0 &amp;&amp; historyList.getFirst().fromDate.toInstant() &lt; invitationDate?.toInstant() ))">
+                    <if condition="historyList.size() == 0">
+                        <then>
+                            <!-- if account has not logged in yet (ie, new user), create one & send a USER_INVITE_RESET_PASSWORD email -->
+                            <!-- reset the password to a random value -->
+                            <set field="resetPassword" from="getRandomString(12)"/>
+                            <set field="passwordNode" from="ec.ecfi.confXmlRoot.first('user-facade').first('password')"/>
+                            <set field="userAccount.resetPassword" from="ec.ecfi.getSimpleHash(resetPassword, userAccount.passwordSalt, userAccount.passwordHashType, 'Y'.equals(userAccount.passwordBase64))"/>
+                            <set field="userAccount.requirePasswordChange" from="(passwordNode.attribute('email-require-change') == 'true') ? 'Y' : 'N'"/>
+                            <entity-update value-field="userAccount"/>
+
+                            <set field="emailsSentList" from="emailsSentList + [partyId:listParty.partyId,
+                                emailAddress:userAccount.emailAddress,emailTemplateId:'USER_INVITE_RESET_PASSWORD']"/>
+                            <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
+                                contactListId:'CoarchyInvitation',emailTemplateId:'USER_INVITE_RESET_PASSWORD',
+                                partyId:listParty.partyId,preferredContactMechId:null,toAddresses:userAccount.emailAddress,
+                                bodyParameters:[linkUrl:baseLinkUrl+'/ChangePassword?username='+userAccount.emailAddress+'&amp;oldPassword='+resetPassword,
+                                title:invitation?.subject?:'You\'re invited to join Coarchy',baseLinkUrl:baseLinkUrl]]" out-map="context"/>
+                        </then>
+                        <else>
+                            <set field="emailsSentList" from="emailsSentList + [partyId:listParty.partyId,
+                                emailAddress:userAccount.emailAddress,emailTemplateId:'USER_INVITE']"/>
+                            <!-- if account has logged in, existing/invited user, but NOT part of inviting organization, send a USER_INVITE email -->
+                            <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
+                                contactListId:'CoarchyInvitation',emailTemplateId:'USER_INVITE',
+                                partyId:listParty.partyId,preferredContactMechId:null,toAddresses:userAccount.emailAddress,
+                                bodyParameters:[linkUrl:baseLinkUrl+'/Login?username='+userAccount.username?:userAccount.emailAddress,
+                                title:invitation?.subject?:'You\'re invited to join Coarchy',baseLinkUrl:baseLinkUrl]]" out-map="context"/>
+                        </else>
+                    </if>
+                </if>
+            </iterate>
+        </actions>
+    </service>
+
+    <service verb="send" noun="NewsletterEmails" authenticate="anonymous-all">
+        <in-parameters>
+            <parameter name="currentTimestamp" default="ec.user.nowTimestamp" type="Timestamp" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="emailsSentList" type="List"/>
+            <parameter name="newsletterPartyIdList" type="List"/>
+        </out-parameters>
+        <actions>
+            <set field="emailsSentList" from="[]"/>
+            <set field="newsletterPartyIdList" from="[]"/>
+            <set field="baseLinkUrl" from="!'production'.equals(System.getProperty('instance_purpose')) ? 'http://localhost:8080' : 'https://coarchy.com'"/>
+
+            <set field="twoDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(2).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="fourDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(4).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="sixDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(6).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="eightDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusDays(8).toInstant().toEpochMilli())" type="Timestamp"/>
+            <set field="twoWeeksAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
+                    (long) currentTimestamp.time), ZoneId.systemDefault()).minusWeeks(2).toInstant().toEpochMilli())" type="Timestamp"/>
+          
+            <entity-find entity-name="mantle.marketing.contact.ContactListParty" list="invitationPartyList">
+                <econdition field-name="contactListId" value="CoarchyInvitation"/>
+                <econdition field-name="statusId" value="CLPT_IN_USE"/>
+                <date-filter/></entity-find>
+            <set field="invitationPartyIdList" from="invitationPartyList*.partyId"/>
+            
+            <!-- Find last time when newsletter email was sent -->
+            <!-- If a newsletter email hasn't been sent in 2 weeks, send a newsletter email. -->
+            <entity-find entity-name="moqui.resource.wiki.WikiBlogCategory" list="wikiBlogCategoryList" for-update="true">
+                <econdition field-name="wikiPageCategoryId" value="Newsletter"/>
+                <econdition field-name="sentDate" operator="is-null"/>
+                <order-by field-name="lastUpdatedStamp"/></entity-find>
+            <entity-find entity-name="moqui.resource.wiki.WikiBlogCategory" list="sentWikiBlogCategoryList" limit="1">
+                <econdition field-name="wikiPageCategoryId" value="Newsletter"/>
+                <econdition field-name="sentDate" operator="is-not-null"/>
+                <order-by field-name="-sentDate"/></entity-find>
+            <set field="wikiBlogCategory" from="wikiBlogCategoryList?.getFirst()"/>
+            <entity-find-one entity-name="moqui.resource.wiki.WikiBlog" value-field="wikiBlog" for-update="true"
+                    auto-field-map="[wikiBlogId:wikiBlogCategory?.wikiBlogId]"/>
+            <entity-find entity-name="moqui.resource.wiki.WikiPage" list="wikiPageList">
+                <econdition field-name="wikiPageId" from="wikiBlog?.wikiPageId"/>
+                <econdition field-name="publishedVersionName" operator="is-not-null"/>
+            </entity-find>
+            <set field="wikiPage" from="wikiPageList?.getFirst()"/>
+            <if condition="!wikiPage">
+                <log level="warn" message="Wiki page not found for blog ${wikiBlog?.wikiBlogId}"/>
+                <else>
+                    <entity-find-one entity-name="moqui.resource.wiki.WikiSpace" value-field="wikiSpace">
+                        <field-map field-name="wikiSpaceId" from="wikiPage.wikiSpaceId"/></entity-find-one>
+                    <set field="rootPageRef" from="ec.resource.getLocationReference(wikiSpace.rootPageLocation)"/>
+                    <set field="pageReference" from="rootPageRef.findChildFile(wikiPage.pagePath)"/>
+
+                    <set field="didSendBlogEmail" from="false"/>
+                    <if condition="wikiBlogCategoryList.size() == 0">
+                        <log level="warn" message="No non sent blog posts found for newsletter"/>
+                        <else-if condition="sentWikiBlogCategoryList.size() == 0 ||
+                            sentWikiBlogCategoryList.getFirst().sentDate.toInstant() &lt; twoWeeksAgo.toInstant()">
+                            <entity-find entity-name="mantle.marketing.contact.ContactListParty" list="newsletterPartyList">
+                                <econdition field-name="contactListId" value="CoarchyNewsletter"/>
+                                <econdition field-name="statusId" value="CLPT_IN_USE"/>
+                                <date-filter/></entity-find>
+                            <set field="newsletterPartyIdList" from="newsletterPartyList*.partyId"/>
+                            <iterate list="invitationPartyList" entry="listParty">
+
+                                <!-- Just assume one user per party -->
+                                <entity-find entity-name="moqui.security.UserAccount" list="userAccountList" limit="2">
+                                    <econdition field-name="partyId" from="listParty.partyId"/>
+                                    <econdition field-name="disabled" operator="not-equals" value="Y"/>
+                                </entity-find>
+                                <if condition="userAccountList.size() &gt; 1">
+                                    <log level="warn" message="Multiple user accounts found for party ${listParty.partyId}"/>
+                                </if>
+                                <set field="userAccount" from="userAccountList?.getFirst()"/>
+
+                                <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
+                                    contactListId:'CoarchyNewsletter',emailTemplateId:'BLOG',
+                                    partyId:listParty.partyId,preferredContactMechId:null,toAddresses:userAccount.emailAddress,
+                                    bodyParameters:[imageUrl:baseLinkUrl+'/content/downloadSmallImage?wikiBlogId='+wikiBlog.wikiBlogId,
+                                    title:wikiBlog.title,author:wikiBlog.author,publishDate:ec.l10n.format(wikiBlog.publishDate, 'MMM dd, yyyy'),
+                                    pageText:pageReference.getText(wikiPage.publishedVersionName),summary:wikiBlog.summary,
+                                    baseLinkUrl:baseLinkUrl]]" out-map="context"/>
+                                <if condition="sentEmail">
+                                    <set field="emailsSentList" from="emailsSentList + [partyId:listParty.partyId,
+                                        emailAddress:userAccount.emailAddress,emailTemplateId:'BLOG']"/>
+                                    <set field="didSendBlogEmail" value="true"/>
+                                </if>
+                            </iterate>
+                        </else-if>
+                    </if>
+                    <if condition="didSendBlogEmail">
+                        <set field="wikiBlogCategory.sentDate" from="currentTimestamp"/>
+                        <entity-update value-field="wikiBlogCategory"/>
+                    </if>
+                </else>
+            </if>
+        </actions>
+    </service>
+
+    <service verb="send" noun="OnboardingEmails" authenticate="anonymous-all">
         <in-parameters>
             <parameter name="currentTimestamp" default="ec.user.nowTimestamp" type="Timestamp" required="true"/>
         </in-parameters>
         <out-parameters>
             <parameter name="emailsSentList" type="List"/>
             <parameter name="onboardingPartyIdList" type="List"/>
-            <parameter name="invitationPartyIdList" type="List"/>
-            <parameter name="newsletterPartyIdList" type="List"/>
         </out-parameters>
         <actions>
             <set field="emailsSentList" from="[]"/>
@@ -3023,7 +3230,8 @@ along with this software (see the LICENSE.md file). If not, see
             <entity-find entity-name="mantle.marketing.contact.ContactListParty" list="onboardingPartyList">
                 <econdition field-name="contactListId" value="CoarchyOnboarding"/>
                 <econdition field-name="statusId" value="CLPT_IN_USE"/>
-                <date-filter/></entity-find>
+                <date-filter/>
+            </entity-find>
             <set field="onboardingPartyIdList" from="onboardingPartyList*.partyId"/>
 
             <set field="twoDaysAgo" from="new Timestamp(ZonedDateTime.ofInstant(Instant.ofEpochMilli(
@@ -3180,186 +3388,8 @@ along with this software (see the LICENSE.md file). If not, see
                         emailAddress:userAccount.emailAddress,emailTemplateId:emailTemplateId]"/>
                 </if>
 
-<!--                <if condition="ownedOrganizationList.size() &gt; 0"><then>-->
-<!--                    <log level="warn" message="Organization already created for party ${listParty.partyId}"/>-->
-<!--                </then></if>-->
-<!--                <if condition="!userAccount"><then>-->
-<!--                    <log level="warn" message="User account not found for party ${listParty.partyId}"/>-->
-<!--                </then></if>-->
-<!--                <if condition="historyList.size() &gt; 0">-->
-<!--                    <log level="warn" message="User ${userAccount.userId} has logged in ${historyList.size()} times"/>-->
-<!--                </if>-->
-<!--                <if condition="twoDaysAgo.toInstant() &lt; historyList.getFirst().fromDate.toInstant()"><then>-->
-<!--                    <log level="warn" message="User ${userAccount.userId} has signed up within the last 2 days"/>-->
-<!--                </then></if>-->
-<!--                <if condition="createOrganizationAlreadyBeenSent">-->
-<!--                    <log level="warn" message="Email ${createOrganizationEmailTemplateId} already sent to party ${listParty.partyId}"/>-->
-<!--                </if>-->
-<!--                <if condition="inviteUserEmailTemplateId">-->
-<!--                    <log level="warn" message="Email ${inviteUserEmailTemplateId} already sent to party ${listParty.partyId}"/>-->
-<!--                </if>-->
-<!--                <if condition="createProcessStoryAlreadyBeenSent">-->
-<!--                    <log level="warn" message="Email ${createProcessStoryEmailTemplateId} already sent to party ${listParty.partyId}"/>-->
-<!--                </if>-->
-<!--                <if condition="createActorAlreadyBeenSent">-->
-<!--                    <log level="warn" message="Email ${createActorEmailTemplateId} already sent to party ${listParty.partyId}"/>-->
-<!--                </if>-->
-
-<!--                <log level="warn" message="send#DailyEmails context.toString() ${context.toString()}"/>-->
             </iterate>
 
-            <entity-find entity-name="mantle.marketing.contact.ContactListParty" list="invitationPartyList">
-                <econdition field-name="contactListId" value="CoarchyInvitation"/>
-                <econdition field-name="statusId" value="CLPT_IN_USE"/>
-                <date-filter/></entity-find>
-            <set field="invitationPartyIdList" from="invitationPartyList*.partyId"/>
-
-            <iterate list="invitationPartyList" entry="listParty">
-                <!-- check when first invitiation email has was sent -->
-                <entity-find entity-name="mantle.marketing.contact.ContactListCommStatus" list="commStatusList">
-                    <econdition field-name="partyId" from="listParty.partyId"/>
-                    <econdition field-name="contactListId" from="listParty.contactListId"/>
-                    <order-by field-name="-lastUpdatedStamp"/></entity-find>
-                <set field="invitationList" from="[]"/>
-                <iterate list="commStatusList" entry="commStatus">
-                    <entity-find-one entity-name="mantle.party.communication.CommunicationEvent" value-field="communicationEvent"
-                            auto-field-map="[communicationEventId:commStatus.communicationEventId]">
-                        <select-field field-name="emailMessageId,entryDate"/>
-                    </entity-find-one>
-                    <entity-find-one entity-name="moqui.basic.email.EmailMessage" value-field="emailMessage"
-                            auto-field-map="[emailMessageId:communicationEvent.emailMessageId]">
-                        <select-field field-name="emailTemplateId,subject"/>
-                    </entity-find-one>
-                    <if condition="['USER_INVITE_RESET_PASSWORD','USER_INVITE'].contains(emailMessage?.emailTemplateId)">
-                        <set field="invitationDate" from="communicationEvent.entryDate"/>
-                        <set field="emailTemplateId" from="emailMessage.emailTemplateId"/>
-                        <set field="invitationList" from="invitationList + [invitationDate:invitationDate,
-                            emailTemplateId:emailTemplateId,subject:emailMessage.subject]"/>
-                    </if>
-                </iterate>
-
-                <!-- Just assume one user per party -->
-                <entity-find entity-name="moqui.security.UserAccount" list="userAccountList" limit="2" for-update="true">
-                    <econdition field-name="partyId" from="listParty.partyId"/>
-                    <econdition field-name="disabled" operator="not-equals" value="Y"/>
-                </entity-find>
-                <if condition="userAccountList.size() &gt; 1">
-                    <log level="warn" message="Multiple user accounts found for party ${listParty.partyId}"/>
-                </if>
-                <set field="userAccount" from="userAccountList?.getFirst()"/>
-
-                <entity-find entity-name="moqui.security.UserLoginHistory" list="historyList" limit="1">
-                    <econdition field-name="userId" from="userAccount.userId"/>
-                    <order-by field-name="fromDate"/></entity-find>
-
-                <set field="invitation" from="invitationList.max{ it.invitationDate }"/>
-                <set field="invitationDate" from="invitation?.invitationDate"/>
-
-                <if condition="invitationList.size() &lt; 3 &amp;&amp; userAccount &amp;&amp;
-                     twoDaysAgo.toInstant() &gt; invitationDate?.toInstant() &amp;&amp;
-                    (historyList.size() == 0 || (historyList.size() &gt; 0 &amp;&amp; historyList.getFirst().fromDate.toInstant() &lt; invitationDate?.toInstant() ))">
-                    <if condition="historyList.size() == 0">
-                        <then>
-                            <!-- if account has not logged in yet (ie, new user), create one & send a USER_INVITE_RESET_PASSWORD email -->
-                            <!-- reset the password to a random value -->
-                            <set field="resetPassword" from="getRandomString(12)"/>
-                            <set field="passwordNode" from="ec.ecfi.confXmlRoot.first('user-facade').first('password')"/>
-                            <set field="userAccount.resetPassword" from="ec.ecfi.getSimpleHash(resetPassword, userAccount.passwordSalt, userAccount.passwordHashType, 'Y'.equals(userAccount.passwordBase64))"/>
-                            <set field="userAccount.requirePasswordChange" from="(passwordNode.attribute('email-require-change') == 'true') ? 'Y' : 'N'"/>
-                            <entity-update value-field="userAccount"/>
-
-                            <set field="emailsSentList" from="emailsSentList + [partyId:listParty.partyId,
-                                emailAddress:userAccount.emailAddress,emailTemplateId:'USER_INVITE_RESET_PASSWORD']"/>
-                            <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
-                                contactListId:'CoarchyInvitation',emailTemplateId:'USER_INVITE_RESET_PASSWORD',
-                                partyId:listParty.partyId,preferredContactMechId:null,toAddresses:userAccount.emailAddress,
-                                bodyParameters:[linkUrl:baseLinkUrl+'/ChangePassword?username='+userAccount.emailAddress+'&amp;oldPassword='+resetPassword,
-                                title:invitation?.subject?:'You\'re invited to join Coarchy',baseLinkUrl:baseLinkUrl]]" out-map="context"/>
-                        </then>
-                        <else>
-                            <set field="emailsSentList" from="emailsSentList + [partyId:listParty.partyId,
-                                emailAddress:userAccount.emailAddress,emailTemplateId:'USER_INVITE']"/>
-                            <!-- if account has logged in, existing/invited user, but NOT part of inviting organization, send a USER_INVITE email -->
-                            <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
-                                contactListId:'CoarchyInvitation',emailTemplateId:'USER_INVITE',
-                                partyId:listParty.partyId,preferredContactMechId:null,toAddresses:userAccount.emailAddress,
-                                bodyParameters:[linkUrl:baseLinkUrl+'/Login?username='+userAccount.username?:userAccount.emailAddress,
-                                title:invitation?.subject?:'You\'re invited to join Coarchy',baseLinkUrl:baseLinkUrl]]" out-map="context"/>
-                        </else>
-                    </if>
-                </if>
-            </iterate>
-
-            <!-- Find last time when newsletter email was sent -->
-
-            <!-- If a newsletter email hasn't been sent in 2 weeks, send a newsletter email. -->
-            <entity-find entity-name="moqui.resource.wiki.WikiBlogCategory" list="wikiBlogCategoryList">
-                <econdition field-name="wikiPageCategoryId" value="Newsletter"/>
-                <econdition field-name="sentDate" operator="is-null"/>
-                <order-by field-name="lastUpdatedStamp"/></entity-find>
-            <entity-find entity-name="moqui.resource.wiki.WikiBlogCategory" list="sentWikiBlogCategoryList" limit="1">
-                <econdition field-name="wikiPageCategoryId" value="Newsletter"/>
-                <econdition field-name="sentDate" operator="is-not-null"/>
-                <order-by field-name="-sentDate"/></entity-find>
-            <set field="wikiBlogCategory" from="wikiBlogCategoryList?.getFirst()"/>
-            <entity-find-one entity-name="moqui.resource.wiki.WikiBlog" value-field="wikiBlog" for-update="true"
-                    auto-field-map="[wikiBlogId:wikiBlogCategory?.wikiBlogId]"/>
-            <entity-find entity-name="moqui.resource.wiki.WikiPage" list="wikiPageList">
-                <econdition field-name="wikiPageId" from="wikiBlog?.wikiPageId"/>
-                <econdition field-name="publishedVersionName" operator="is-not-null"/>
-            </entity-find>
-            <set field="wikiPage" from="wikiPageList?.getFirst()"/>
-            <if condition="!wikiPage">
-                <log level="warn" message="Wiki page not found for blog ${wikiBlog?.wikiBlogId}"/>
-                <else>
-                    <entity-find-one entity-name="moqui.resource.wiki.WikiSpace" value-field="wikiSpace">
-                        <field-map field-name="wikiSpaceId" from="wikiPage.wikiSpaceId"/></entity-find-one>
-                    <set field="rootPageRef" from="ec.resource.getLocationReference(wikiSpace.rootPageLocation)"/>
-                    <set field="pageReference" from="rootPageRef.findChildFile(wikiPage.pagePath)"/>
-
-                    <set field="didSendBlogEmail" from="false"/>
-                    <if condition="wikiBlogCategoryList.size() == 0">
-                        <log level="warn" message="No non sent blog posts found for newsletter"/>
-                        <else-if condition="sentWikiBlogCategoryList.size() == 0 ||
-                            sentWikiBlogCategoryList.getFirst().sentDate.toInstant() &lt; twoWeeksAgo.toInstant()">
-                            <entity-find entity-name="mantle.marketing.contact.ContactListParty" list="newsletterPartyList">
-                                <econdition field-name="contactListId" value="CoarchyNewsletter"/>
-                                <econdition field-name="statusId" value="CLPT_IN_USE"/>
-                                <date-filter/></entity-find>
-                            <set field="newsletterPartyIdList" from="newsletterPartyList*.partyId"/>
-                            <iterate list="invitationPartyList" entry="listParty">
-
-                                <!-- Just assume one user per party -->
-                                <entity-find entity-name="moqui.security.UserAccount" list="userAccountList" limit="2" for-update="true">
-                                    <econdition field-name="partyId" from="listParty.partyId"/>
-                                    <econdition field-name="disabled" operator="not-equals" value="Y"/>
-                                </entity-find>
-                                <if condition="userAccountList.size() &gt; 1">
-                                    <log level="warn" message="Multiple user accounts found for party ${listParty.partyId}"/>
-                                </if>
-                                <set field="userAccount" from="userAccountList?.getFirst()"/>
-
-                                <service-call name="coarchy.CoarchyServices.send#ContactListEmail" in-map="[
-                                    contactListId:'CoarchyNewsletter',emailTemplateId:'BLOG',
-                                    partyId:listParty.partyId,preferredContactMechId:null,toAddresses:userAccount.emailAddress,
-                                    bodyParameters:[imageUrl:baseLinkUrl+'/content/downloadSmallImage?wikiBlogId='+wikiBlog.wikiBlogId,
-                                    title:wikiBlog.title,author:wikiBlog.author,publishDate:ec.l10n.format(wikiBlog.publishDate, 'MMM dd, yyyy'),
-                                    pageText:pageReference.getText(wikiPage.publishedVersionName),summary:wikiBlog.summary,
-                                    baseLinkUrl:baseLinkUrl]]" out-map="context"/>
-                                <if condition="sentEmail">
-                                    <set field="emailsSentList" from="emailsSentList + [partyId:listParty.partyId,
-                                        emailAddress:userAccount.emailAddress,emailTemplateId:'BLOG']"/>
-                                    <set field="didSendBlogEmail" value="true"/>
-                                </if>
-                            </iterate>
-                        </else-if>
-                    </if>
-                    <if condition="didSendBlogEmail">
-                        <set field="wikiBlogCategory.sentDate" from="currentTimestamp"/>
-                        <entity-update value-field="wikiBlogCategory"/>
-                    </if>
-                </else>
-            </if>
         </actions>
     </service>
 


### PR DESCRIPTION
Changes:
- Split send#DailyEmails into send#NewsletterEmails, send#OnboardingEmails, and send#InvitationEmails
- In seed data, Removed service job send#DailyEmails
- In seed data, added service job definitions to send#NewsletterEmails, send#OnboardingEmails, and send#InvitationEmails

Note: for backwards compatibility, either pause the send#DailyEmails service, OR remove associated records (ServiceJob, ServiceJobLock, ServiceJobRun) 