### PR TITLE
New Feature: Optional copy on write

### DIFF
--- a/screen/coarchy/cointernal/Process/EditProcessStory/UpdateActivity.xml
+++ b/screen/coarchy/cointernal/Process/EditProcessStory/UpdateActivity.xml
@@ -38,6 +38,14 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="activityId"/>
             <order-by field-name="name"/></entity-find>
         <set field="actorIdList" from="activityActorList*.actorId"/>
+
+        <entity-find-count entity-name="coarchy.product.ProductEvaluationActivityAndDetail" count-field="existingEvaluationRecordCount">
+            <econdition field-name="statusId" operator="not-equals" value="PeRequirementsSelection"/>
+            <econdition field-name="activityId" />
+            <econdition field-name="excludeFlag" value="N" or-null="true" />
+            <econdition field-name="organizationId" from="activeOrgId" />
+       </entity-find-count>
+       <set field="canCopyOnWrite" from="existingEvaluationRecordCount &gt; 0" />
     </actions>
 
     <widgets>
@@ -60,6 +68,17 @@ along with this software (see the LICENSE.md file). If not, see
                             <order-by field-name="sequenceNum"/></entity-find>
                     </entity-options>
                 </drop-down></default-field>
+            </field>
+            <field name="ignoreCopyOnWrite">
+                <conditional-field title="" condition="canCopyOnWrite">
+                    <label text="This activity was used in at least one Product Evaluation. Do you also want these changes applied to any product evaluation? Warning! This is unreversible." style="text-negative" />
+                    <check no-current-selected-key="false">
+                        <option key="true" text="Yes, save the changes to all existing product evaluations." />
+                    </check>
+                </conditional-field>
+                <default-field title="">
+                    <hidden />
+                </default-field>
             </field>
             <field name="submit"><default-field><submit text="Update"/></default-field></field>
         </form-single>

--- a/screen/coarchy/cointernal/Process/ProcessStory.xml
+++ b/screen/coarchy/cointernal/Process/ProcessStory.xml
@@ -313,6 +313,13 @@ along with this software (see the LICENSE.md file). If not, see
                     <order-by field-name="name"/></entity-find>
                 <set field="actorIdList" from="activityActorList*.actorId"/>
 
+                <entity-find-count entity-name="coarchy.product.ProductEvaluationActivityAndDetail" count-field="existingEvaluationRecordCount">
+                    <econdition field-name="statusId" operator="not-equals" value="PeRequirementsSelection"/>
+                    <econdition field-name="activityId" />
+                    <econdition field-name="excludeFlag" value="N" or-null="true" />
+                    <econdition field-name="organizationId" from="activeOrgId" />
+               </entity-find-count>
+               <set field="canCopyOnWrite" from="existingEvaluationRecordCount &gt; 0" />        
                 <!--                <log level="warn" message="form-list ProcessStory context.toString() ${context.toString()}"/>-->
             </row-actions>
             <row-selection id-field="activityId">
@@ -430,7 +437,7 @@ along with this software (see the LICENSE.md file). If not, see
                         </entity-options>
                     </drop-down>
                 </header-field>
-                <conditional-field condition="action"><drop-down allow-empty="true" submit-on-select="true">
+                <conditional-field condition="action"><drop-down allow-empty="true" submit-on-select="false">
                     <entity-options key="${enumId}" text="${description}">
                         <entity-find entity-name="moqui.basic.Enumeration">
                             <econdition field-name="enumTypeId" value="ActivityImplementation"/>
@@ -453,7 +460,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <list-options list="headerActorList" key="${actorId}" text="${name}"/>
                     <dynamic-options server-search="true" transition="getActorList" min-length="0"/>
                 </drop-down></header-field>
-                <conditional-field condition="action" title="Actor"><drop-down allow-empty="true" allow-multiple="true" submit-on-select="true">
+                <conditional-field condition="action" title="Actor"><drop-down allow-empty="true" allow-multiple="true" submit-on-select="false">
                     <list-options list="activityActorList" key="${actorId}" text="${name}"/>
                     <dynamic-options server-search="true" transition="getActorList" min-length="0"/>
                 </drop-down></conditional-field>
@@ -463,9 +470,19 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="action"><header-field title="Action" show-order-by="case-insensitive"><text-find size="25"/></header-field>
                 <conditional-field condition="action"><text-area rows="2" cols="80" autogrow="true"/></conditional-field>
                 <last-row-field><text-area rows="2" cols="80"/></last-row-field></field>
-
+            <field name="ignoreCopyOnWrite">
+                <conditional-field title="" condition="canCopyOnWrite">
+                    <!-- <label text="This activity was used in at least one Product Evaluation. Do you also want these changes applied to any product evaluation? Warning! This is unreversible." style="text-negative" /> -->
+                    <check no-current-selected-key="false">
+                        <option key="true" text="Save the changes to all existing product evaluations." />
+                    </check>
+                </conditional-field>
+                <default-field title="">
+                    <hidden />
+                </default-field>
+            </field>
             <field name="submit"><header-field title="Update"><submit/></header-field>
-                <conditional-field condition="action"><submit text="Update"/></conditional-field>
+                <conditional-field condition="action"><submit text="Update" /></conditional-field>
                 <last-row-field><submit text="Add Activity" type="success"/></last-row-field></field>
 
             <field name="actionMenu"><default-field title="Actions">
@@ -494,7 +511,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <column><field-ref name="move"/></column>
                 <column><field-ref name="condition"/><field-ref name="implementationId"/></column>
                 <column><field-ref name="actorIdList"/><field-ref name="action"/></column>
-                <column><field-ref name="submit"/></column>
+                <column><field-ref name="ignoreCopyOnWrite" /><field-ref name="submit"/></column>
                 <column><field-ref name="actionMenu"/><field-ref name="newParagraph"/></column>
             </columns>
         </form-list>

--- a/screen/coarchy/cointernal/ValueStatements.xml
+++ b/screen/coarchy/cointernal/ValueStatements.xml
@@ -41,7 +41,7 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
 
     <transition name="updateValue"><condition><expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression></condition>
-        <service-call name="coarchy.CoarchyServices.update#ValueStatement" in-map="[valueStatementId:valueStatementId,activityIdList:activityIdList,tagIdList:tagIdList,value:value,typeEnumId:typeEnumId,sequenceNum:sequenceNum,organizationId:activeOrgId]"/>
+        <service-call name="coarchy.CoarchyServices.update#ValueStatement" in-map="[valueStatementId:valueStatementId,activityIdList:activityIdList,tagIdList:tagIdList,value:value,typeEnumId:typeEnumId,sequenceNum:sequenceNum,ignoreCopyOnWrite:ignoreCopyOnWrite,organizationId:activeOrgId]"/>
         <default-response/><error-response url="." save-parameters="true"/>
     </transition>
 
@@ -323,6 +323,13 @@ along with this software (see the LICENSE.md file). If not, see
                 </entity-find>
                 <set field="tagIdList" from="statementTagList*.tagId"/>
                 
+                <entity-find-count entity-name="coarchy.product.ProductEvaluationStatementAndDetail" count-field="existingEvaluationRecordCount">
+                    <econdition field-name="statusId" operator="not-equals" value="PeRequirementsSelection"/>
+                    <econdition field-name="statementId" from="valueStatementId" />
+                    <econdition field-name="organizationId" from="activeOrgId" />
+               </entity-find-count>
+               <set field="canCopyOnWrite" from="existingEvaluationRecordCount &gt; 0" />
+
 <!--                <log level="warn" message="form-list Statements context.toString() ${context.toString()}"/>-->
             </row-actions>
 
@@ -366,7 +373,7 @@ along with this software (see the LICENSE.md file). If not, see
                             <order-by field-name="sequenceNum"/></entity-find>
                     </entity-options>
                 </drop-down></header-field>
-                <default-field title="Statement Type"><drop-down submit-on-select="true">
+                <default-field title="Statement Type"><drop-down submit-on-select="false">
                     <entity-options key="${enumId}" text="${description}">
                         <entity-find entity-name="moqui.basic.Enumeration">
                             <econdition field-name="enumTypeId" value="ValueType"/>
@@ -385,6 +392,18 @@ along with this software (see the LICENSE.md file). If not, see
             </field>
             <field name="valueStatementId">
                 <default-field><hidden/></default-field></field>
+            <field name="ignoreCopyOnWrite">
+                <conditional-field title="" condition="canCopyOnWrite">
+                    <!-- not enought space for this -->
+                    <!-- <label text="This statement was used in at least one Product Evaluation. Do you also want these changes applied to any product evaluation? Warning! This is unreversible." style="text-negative" /> -->
+                    <check no-current-selected-key="false">
+                        <option key="true" text="Save the changes to all existing product evaluations." />
+                    </check>
+                </conditional-field>
+                <default-field title="">
+                    <hidden />
+                </default-field>
+            </field>
             <field name="submit">
                 <header-field><submit text="Submit"/></header-field>
                 <default-field><submit text="Update"/></default-field>
@@ -495,7 +514,7 @@ along with this software (see the LICENSE.md file). If not, see
             </field>        
             <columns>
                 <column><field-ref name="value"/><field-ref name="tagIdList"/></column>
-                <column><field-ref name="typeEnumId"/></column>
+                <column><field-ref name="typeEnumId"/><field-ref name="ignoreCopyOnWrite" /></column>
                 <column><field-ref name="submit"/></column>
                 <column><field-ref name="actions"/></column>
             </columns>

--- a/service/coarchy/CoarchyServices.xml
+++ b/service/coarchy/CoarchyServices.xml
@@ -913,6 +913,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="action" required="true"/>
             <parameter name="implementationId"/>
             <parameter name="organizationId" required="true"/>
+            <parameter name="ignoreCopyOnWrite" type="Boolean" default="false"/>
         </in-parameters>
         <actions>
              <!-- check if activity is references in product evaluation records of status other than RequirementsSelection -->
@@ -929,7 +930,8 @@ along with this software (see the LICENSE.md file). If not, see
             <entity-find-one entity-name="coarchy.Activity" value-field="activity">
                 <field-map field-name="activityId" />
             </entity-find-one>
-            <if condition="activity.condition != condition?.trim() || activity.action != action?.trim() || activity.implementationId != implementationId">
+ 
+            <if condition="(activity.condition?:'') != (condition?.trim()?:'') || (activity.action?:'') != (action?.trim()?:'') || (activity.implementationId?:'') != (implementationId?:'')">
                 <set field="valueChanged" from="true"/>
             </if>
 
@@ -939,7 +941,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="activityId" />
                     <econdition field-name="organizationId" />
                 </entity-find>
-                <if condition="!activityActorList*.actorIds.equals(actorIdList)">
+                <if condition="!activityActorList*.actorId.equals(actorIdList)">
                     <set field="valueChanged" from="true"/>
                 </if>
             </if>
@@ -949,7 +951,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <return />
             </if>
 
-            <if condition="existingEvaluationRecords">
+            <if condition="existingEvaluationRecords &amp;&amp; !ignoreCopyOnWrite">
                 <!-- we have ProductEvaluationItem records, perform copy on write -->             
 
                 <!-- duplicate existing activity -->
@@ -1501,6 +1503,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="typeEnumId"/>
             <parameter name="sequenceNum"/>
             <parameter name="organizationId" required="true"/>
+            <parameter name="ignoreCopyOnWrite" type="Boolean" default="false"/>
         </in-parameters>
         <out-parameters>
             <parameter name="valueStatementId"/>
@@ -1529,13 +1532,13 @@ along with this software (see the LICENSE.md file). If not, see
            <entity-find-one entity-name="coarchy.ValueStatement" value-field="valueStatement">
                <field-map field-name="valueStatementId" />
            </entity-find-one>
-           <if condition="valueStatement.value != value?.trim() || valueStatement.typeEnumId != typeEnumId || valueStatement.sequenceNum != sequenceNum">
+           <if condition="(valueStatement.value?:'') != (value?.trim()?:'') || (valueStatement.typeEnumId?:'') != (typeEnumId?:'')">
                <set field="valueChanged" from="true"/>
            </if>
 
            <!-- nothing changed, return -->
            <if condition="valueChanged">
-                <if condition="existingEvaluationRecords">
+                <if condition="existingEvaluationRecords &amp;&amp; !ignoreCopyOnWrite">
                     <then>
                         <!-- duplicate existing value statement -->
                         <service-call name="create#coarchy.ValueStatement" in-map="valueStatement + [valueStatementId:null, value:value,typeEnumId:typeEnumId]" out-map="newStatementOut"/>


### PR DESCRIPTION
Changes:
- Added optional copy on write on update for Value Statements & Activities. 
- Fixed a minor bug in checking whether valuestatements/activities had any values that changed. 

Affected screens are ProcessStory, EditProcessStory and ValueStatements.

