### PR TITLE
Quickfix for vendor browsing public org from Organizations screen

### DIFF
--- a/screen/settings/settingsinternal/Organizations.xml
+++ b/screen/settings/settingsinternal/Organizations.xml
@@ -100,11 +100,14 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="goToApplication"><actions>
         <entity-find-one entity-name="moqui.security.UserPreference" value-field="userPreference" auto-field-map="[userId:ec.user.userId,preferenceKey:'ACTIVE_ORGANIZATION']"/>
         <if condition="partyId &amp;&amp; userPreference?.preferenceValue != partyId">
-            <entity-find-count entity-name="mantle.party.PartyRelationship" count-field="partyRelationshipCount">
+            <entity-find-count entity-name="mantle.party.PartyToAndRelationship" count-field="partyRelationshipCount">
                 <date-filter/>
                 <econdition field-name="relationshipTypeEnumId" value="PrtMember"/>
                 <econdition field-name="toRoleTypeId" value="OrgInternal"/>
-                <econdition field-name="fromPartyId" from="ec.user.userAccount.partyId"/>
+                <econditions combine="or">
+                    <econdition field-name="fromPartyId" from="ec.user.userAccount.partyId"/>
+                    <econdition field-name="visibilityEnumId" value="PvPublic"/>
+                </econditions>
                 <econdition field-name="toPartyId" from="partyId"/></entity-find-count>
             <if condition="partyRelationshipCount &gt; 0">
                 <service-call name="org.moqui.impl.UserServices.set#Preference" in-map="[preferenceKey:'ACTIVE_ORGANIZATION',preferenceValue:partyId]"/>


### PR DESCRIPTION
Current behavior:
If vendor clicks on 'Coarchy', a public org in the organizations screen, it'll show an error page since activeOrgId was not set before redirect.

Changes:
- In Organizations screen, fix goToApplication transition not setting activeOrgId for public organizations.