### PR TITLE
Resolves Task CoarchyP-100133: Product eval fixes

### DIFF
--- a/screen/coarchy/cointernal/Products/EditProductEval.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval.xml
@@ -32,73 +32,19 @@ along with this software (see the LICENSE.md file). If not, see
             <date-filter/>
             <econdition field-name="partyId" from="activeOrgId"/>
         </entity-find-count>
-    </always-actions>
 
-    <transition name="inviteVendor">
-        <condition>
-            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
-        </condition>
-        <service-call name="coarchy.ProductEvaluationServices.add#ProductEvaluationParty" in-map="[productEvaluationId:productEvaluationId,emailAddress:emailAddress,firstName:firstName,lastName:lastName,organizationId:activeOrgId]"/>
-        <default-response url="." type="screen-last" />
-    </transition>
-
-    <transition name="finalizeActivitySelection">
-        <condition>
-            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
-        </condition>
-        <service-call name="coarchy.ProductEvaluationServices.finalize#ProductEvaluationActivitySelection" in-map="[productEvaluationId:productEvaluationId]"/>
-        <default-response url="." type="screen-last"/>
-    </transition>
-
-    <transition name="finalizeVendorInvitations">
-        <condition>
-            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
-        </condition>
-        <service-call name="coarchy.ProductEvaluationServices.finalize#ProductEvaluationVendorInvitations" in-map="[productEvaluationId:productEvaluationId]"/>
-        <default-response url="." type="screen-last"/>
-    </transition>
-
-    <transition name="reopenActivitySelection">
-        <condition>
-            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
-        </condition>
-        <service-call name="coarchy.ProductEvaluationServices.reopen#ProductEvaluationActivitySelection" in-map="[productEvaluationId:productEvaluationId]"/>
-        <default-response url="." type="screen-last"/>
-    </transition>
-
-    <transition name="cancelProductEvaluation">
-        <condition>
-            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
-        </condition>
-        <service-call name="coarchy.ProductEvaluationServices.cancel#ProductEvaluation" in-map="[productEvaluationId:productEvaluationId]"/>
-        <default-response url="." type="screen-last"/>
-    </transition>
-
-    <transition name="completeProductEvaluation">
-        <condition>
-            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
-        </condition>
-        <service-call name="coarchy.ProductEvaluationServices.complete#ProductEvaluation" in-map="[productEvaluationId:productEvaluationId]"/>
-        <default-response url="." type="screen-last"/>
-    </transition>
-
-    <transition-include name="upgradeParty" location="component://coarchy/screen/coarchy/cointernal/Home.xml"/>
-
-    <subscreens default-item="EvalStatements">
-        <subscreens-item name="EvalStatements" menu-include="true" menu-index="10" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalStatements.xml"/>
-        <subscreens-item name="EvalProcessStories" menu-include="true" menu-index="20" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalProcessStories.xml"/>
-    </subscreens>
-
-    <actions>
-        <!-- find product eval -->
-        <entity-find-one entity-name="coarchy.product.ProductEvaluationAndProduct" value-field="productEvaluation"/>
-        <set field="statusId" from="productEvaluation?.statusId"/>
-
+        <entity-find-one entity-name="coarchy.product.ProductEvaluation" value-field="productEvaluation"/>
+        <set field="statusId" from="productEvaluation.statusId"/>
+        
         <!-- safegaurd vendors from accessing product evaluation before its ready for them -->
-        <if condition="isVendorView &amp;&amp; ['PeRequirementsSelection','PeInviteVendors'].contains(statusId)">
+        <if condition="isVendorView &amp;&amp; ['PeRequirementsSelection','PeInviteVendors'].contains(productEvaluation.statusId)">
             <return error="true" message="Not allowed"/>
         </if>
 
+        <set field="showReponseListButton" from="['PeAwaitingVendorResponse','PeCompleted','PeCancelled'].contains(statusId)"/>
+        <set field="showVendorRespondButton" from="isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
+        <set field="showInternalRespondButton" from="!isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
+        
         <!-- find invited vendors -->
         <entity-find entity-name="coarchy.product.ProductEvaluationParty" list="vendorRepList">
             <date-filter />
@@ -106,10 +52,6 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="roleTypeId" value="VendorRepresentative" />
         </entity-find>
 
-        <!-- note: isVendorView=true is set in always-actions in vendor app to determine where this is being accessed from -->
-        <set field="isUserInternalOrgMember" from="partyRelationshipCount &gt; 0"/>
-        <set field="isUserVendor" from="(vendorRepList*.partyId).contains(ec.user.userAccount?.partyId)"/>
-        
         <!-- canInviteVendors controls the invite party dialog -->
         <set field="canInviteVendors" from="['PeRequirementsSelection','PeInviteVendors','PeAwaitingVendorResponse'].contains(statusId)"/>
         <!-- showInviteVendorsSection controls the whole vendor rep list section) -->
@@ -117,207 +59,62 @@ along with this software (see the LICENSE.md file). If not, see
 
         <!-- check if all statements and stories have been responded to -->
         <service-call name="coarchy.ProductEvaluationServices.get#ProductEvaluationCompleteWarnings" in-map="[productEvaluationId:productEvaluationId]" out-map="context" />
-    </actions>
+    </always-actions>
+
+    <transition name="inviteVendor">
+        <condition>
+            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
+        </condition>
+        <service-call name="coarchy.ProductEvaluationServices.add#ProductEvaluationParty" in-map="[productEvaluationId:productEvaluationId,emailAddress:emailAddress,firstName:firstName,lastName:lastName,organizationId:activeOrgId]"/>
+        <default-response url="."  />
+    </transition>
+
+    <transition name="finalizeActivitySelection">
+        <condition>
+            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
+        </condition>
+        <service-call name="coarchy.ProductEvaluationServices.finalize#ProductEvaluationActivitySelection" in-map="[productEvaluationId:productEvaluationId]"/>
+        <default-response url="." />
+    </transition>
+
+    <transition name="finalizeVendorInvitations">
+        <condition>
+            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
+        </condition>
+        <service-call name="coarchy.ProductEvaluationServices.finalize#ProductEvaluationVendorInvitations" in-map="[productEvaluationId:productEvaluationId]"/>
+        <default-response url="." />
+    </transition>
+
+    <transition name="reopenActivitySelection">
+        <condition>
+            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
+        </condition>
+        <service-call name="coarchy.ProductEvaluationServices.reopen#ProductEvaluationActivitySelection" in-map="[productEvaluationId:productEvaluationId]"/>
+        <default-response url="." />
+    </transition>
+
+    <transition name="cancelProductEvaluation">
+        <condition>
+            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
+        </condition>
+        <service-call name="coarchy.ProductEvaluationServices.cancel#ProductEvaluation" in-map="[productEvaluationId:productEvaluationId]"/>
+        <default-response url="." />
+    </transition>
+
+    <transition name="completeProductEvaluation">
+        <condition>
+            <expression>partyRelationshipCount &gt; 0 &amp;&amp; partyActivationCount &gt; 0</expression>
+        </condition>
+        <service-call name="coarchy.ProductEvaluationServices.complete#ProductEvaluation" in-map="[productEvaluationId:productEvaluationId]"/>
+        <default-response url="." />
+    </transition>
+
+    <subscreens default-item="EvalStatements">
+        <subscreens-item name="EvalStatements" menu-include="true" menu-index="10" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalStatements.xml"/>
+        <subscreens-item name="EvalProcessStories" menu-include="true" menu-index="20" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalProcessStories.xml"/>
+    </subscreens>
 
     <widgets>
-        <section name="FreemiumBanner" condition="partyActivationCount == 0">
-            <widgets>
-                <container type="q-banner inline-actions rounded dense" style="bg-grey-3 text-black q-mb-md">
-                    <label text="To enable all the features upgrade organization '${activeOrg.organizationName}' to Premium" type="b"/>
-                    <container type="template v-slot:action">
-                        <form-single name="UpgradeForm" transition="upgradeParty">
-                            <field name="upgrade">
-                                <default-field>
-                                    <submit text="Upgrade" type="success" confirmation="Activating will cost 1 Organization-Month Credit per month while ${activeOrg.organizationName} is upgraded. Are you sure?"/>
-                                </default-field>
-                            </field>
-                        </form-single>
-                    </container>
-                </container>
-            </widgets>
-        </section>
-
-        <container>
-            <container-row style="q-mt-md">
-                <row-col sm="8" xs="6">
-                    <label text="Product Evaluation on ${productEvaluation?.productName}" style="text-h4"/>
-                    <label text="(#${productEvaluation?.productEvaluationId})" style="text-subtitle2 text-grey-8"/>
-                    <container style="q-mb-md">
-                        <label text="In the Requirements Selection step, add the requirements you want the product to be evaluated against." style="text-subtitle2 text-grey-8" condition="isUserInternalOrgMember &amp;&amp; (statusId == 'PeRequirementsSelection')"/>
-                        <label text="Send invitations to product vendor representatives with a request for information about the applicability of their product to your requirement statements and process story activities." style="text-subtitle2 text-grey-8" condition="isUserInternalOrgMember &amp;&amp; (statusId == 'PeInviteVendors')"/>
-                        <label text="You are waiting for vendor evaluations. You can track their responses below." style="text-subtitle2 text-grey-8" condition="isUserInternalOrgMember &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
-                        <label text="This Product Evaluation is awaiting your responses. Please review the statements and stories below." style="text-subtitle2 text-grey-8" condition="isUserVendor &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>            
-                    </container>
-                </row-col>
-                <row-col sm="4" xs="6" style="float-right">
-                    <container>
-                        <label text="Status" style="text-bold" />
-                    </container>
-                    <container style="text-subtitle1">
-                        <section name="StatusInteralSection" condition="!isVendorView">
-                            <widgets>
-                                <label text="Requirements Selection" style="${(statusId == 'PeRequirementsSelection')?'text-primary':'text-grey-8'}" />
-                                <label text=" / " />
-                                
-                                <label text="Vendor Invitations" style="${(statusId == 'PeInviteVendors')?'text-primary':'text-grey-8'}" />
-                                <label text=" / " />
-                                
-                                <label text="Awaiting Responses" style="${(statusId == 'PeAwaitingVendorResponse')?'text-primary':'text-grey-8'}" />
-                                <label text=" / " />
-                            </widgets>
-                            <fail-widgets>
-                                <label text="Awaiting Response" style="${(statusId == 'PeAwaitingVendorResponse')?'text-primary':'text-grey-8'}" />
-                                <label text=" / " />
-                            </fail-widgets>
-                        </section>
-
-                        <label text="Complete" style="${(statusId == 'PeCompleted')?'text-primary':'text-grey-8'}" condition="statusId != 'PeCancelled'"/>                        
-                        <label text="Cancelled" style="text-negative text-bold" condition="(statusId == 'PeCancelled')"/>
-                    </container>
-                </row-col>
-            </container-row>
-        </container>
-
-
-        <section name="EvalActionsSection" condition="!isVendorView">
-            <widgets>
-                <link url="finalizeActivitySelection" text="Finalize Requirements Selection" confirmation="Are you sure you want to finalize the requirements selection?" btn-type="success" tooltip="Finalize Requirements Selection" parameter-map="[productEvaluationId:productEvaluationId]" condition="statusId=='PeRequirementsSelection'" />
-                <link url="reopenActivitySelection" text="Modify Requirements" parameter-map="[productEvaluationId:productEvaluationId]" condition="statusId=='PeInviteVendors'"/>
-                
-                <link url="finalizeVendorInvitations" text="Finalize Invitations" confirmation="Are you sure you want to finalize the vendor invitations?" btn-type="success" tooltip="Finalize Vendor Invitations" parameter-map="[productEvaluationId:productEvaluationId]" condition="statusId=='PeInviteVendors'"/>
-                
-                <link url="cancelProductEvaluation" text="Cancel Evaluation" confirmation="Are you sure you want to cancel this product evaluation?" btn-type="danger" tooltip="Cancel Product Evaluation" parameter-map="[productEvaluationId:productEvaluationId]" condition="['PeRequirementsSelection','PeInviteVendors'].contains(statusId)"/>
-            
-                <section name="CompleteSection" condition="['PeAwaitingVendorResponse'].contains(statusId)">
-                    <widgets>
-                        <link url="completeProductEvaluation" text="Complete Evaluation" confirmation="Are you sure you want to complete this product evaluation?" btn-type="success" tooltip="Complete Product Evaluation" parameter-map="[productEvaluationId:productEvaluationId]" condition="!hasWarnings"/>
-        
-                        <container-dialog id="CompleteEvaluationDialog" button-text="Complete Warnings" condition="hasWarnings" type="success">
-                            <label text="Not all Statements have internal evaluations" style="q-mx-sm text-danger" type="p" condition="!internalRespondedToAllStatements"/>
-                            <label text="Not all Statements have vendor evaluations"  style="q-mx-sm text-danger" type="p" condition="!vendorRespondedToAllStatements"/>
-                            <label text="Not all Process Stories have internal evaluations" style="q-mx-sm text-danger" type="p" condition="!internalRespondedToAllStories"/>
-                            <label text="Not all Process Stories have vendor evaluations" style="q-mx-sm text-danger" type="p" condition="!vendorRespondedToAllStories" />
-                            <link url="completeProductEvaluation" text="Complete Evaluation Anyway" link-type="hidden-form"/>
-                        </container-dialog>
-                    </widgets>
-                </section>
-            </widgets>                
-        </section>
-            
-        <section name="FullWidth" condition="statusId=='PeRequirementsSelection'">
-            <widgets>
-                <container-row>
-                    <row-col sm="12">
-                        <subscreens-panel id="ProductEvalPanel" type="tab" />
-                    </row-col>
-                </container-row>
-            </widgets>
-            <fail-widgets>
-                <container-row >
-                    <row-col sm="8">
-                        <subscreens-panel id="ProductEvalPanel" type="tab" />
-                    </row-col>
-                    <row-col sm="4">
-                        <section name="ProductVendorInviteListSection" condition="showInviteVendorsSection">
-                            <widgets>
-                                <container-box>
-                                    <box-header>
-                                        <container-dialog id="ProductVendorInviteDialog" button-text="${(statusId=='PeAwaitingVendorResponse'?'Invite':'Add')}" button-style="float-right" condition="canInviteVendors">
-                                            <container>
-                                                <label text="Send invitations to product vendor representatives with a request for information about the applicability of their product to your requirement statements and process story activities." condition="!isVendorView"/>                                                   
-                                                <label text="Invite your team members by adding their email address below." condition="isVendorView"/>                                                
-                                            </container>
-                                            <form-single name="ProductVendorInviteForm" transition="inviteVendor">
-                                                <field name="productEvaluationId">
-                                                    <default-field>
-                                                        <hidden />
-                                                    </default-field>
-                                                </field>
-                                                <field name="emailAddress">
-                                                    <default-field>
-                                                        <text-line input-type="email"/>
-                                                    </default-field>
-                                                </field>
-                                                <field name="submit">
-                                                    <default-field>
-                                                        <submit text="Invite"/>
-                                                    </default-field>
-                                                </field>
-                                                <field-layout>
-                                                    <field-col-row>
-                                                        <field-col sm="9">
-                                                            <field-ref name="emailAddress" />
-                                                        </field-col>
-                                                        <field-col sm="3">
-                                                            <field-ref name="submit" />
-                                                        </field-col>
-                                                    </field-col-row>
-                                                </field-layout>
-                                            </form-single>
-                                        </container-dialog>
-                                        <label text="Vendor Representatives" style="text-bold q-mx-md"/>
-                                    </box-header>
-                                    <box-body>
-                                        <label text="Add as many vendor representatives you would like to evaluate the product, against these requirements. Invitations will only be sent when you click 'Finalize Invitations'." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; ['PeRequirementsSelection','PeInviteVendors'].contains(statusId)"/>
-                                        <label text="You have invited the following vendors representatives to evaluate this product. You can either invite more representatives to collaborate, or let the invited representatives add more of their team members." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; ['PeAwaitingVendorResponse'].contains(statusId)"/>
-
-                                        <label text="The following users are part of this evaluation. You can add team members to assist you with this evaluation by clicking on the 'Invite' button." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; ['PeAwaitingVendorResponse'].contains(statusId)"/> 
-                                        
-                                        <label text="The following users are part of this evaluation." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; !['PeAwaitingVendorResponse'].contains(statusId)"/>   
-
-                                        <section name="VendorListSection" condition="vendorRepList">
-                                            <widgets>
-                                                <form-list name="ProductVendorInviteList" list="vendorRepList">
-                                                    <row-actions>
-                                                        <entity-find-one entity-name="mantle.party.PersonAndUserAccount" value-field="personAndAccount">
-                                                            <field-map field-name="partyId" />
-                                                        </entity-find-one>
-                                                    </row-actions>
-                                                    <field name="partyId">
-                                                        <default-field>
-                                                            <hidden/>
-                                                        </default-field>
-                                                    </field>
-                                                    <field name="combinedName">
-                                                        <default-field title="Representative Name">
-                                                            <display text="${personAndAccount?.firstName} ${personAndAccount?.lastName}" parameter-map="personAndAccount"/>
-                                                        </default-field>
-                                                    </field>
-                                                    <field name="emailAddress">
-                                                        <default-field>
-                                                            <display text="${personAndAccount.emailAddress}"/>
-                                                        </default-field>
-                                                    </field>
-                                                    <!-- simplified status -->
-                                                    <field name="statusId">
-                                                        <conditional-field condition="statusId=='PepPlanned'">
-                                                            <display text="Pending" style="text-grey-8"/>
-                                                        </conditional-field>
-                                                        <conditional-field condition="['PepInvited','PepAccepted'].contains(statusId)">
-                                                            <display text="Invited" style="text-grey-8"/>
-                                                        </conditional-field>
-                                                        <default-field title="Status">
-                                                            <!-- <display-entity entity-name="moqui.basic.StatusItem"/> -->
-                                                            <label text="N/A" />
-                                                        </default-field>
-                                                    </field>
-                                                </form-list>
-                                            </widgets>
-                                        </section>
-                                        <section name="NoVendorListSection" condition="!vendorRepList">
-                                            <widgets>
-                                                <container style="text-center">
-                                                    <label text="Please add at least one vendor representative to evaluate this product." style="text-bold text-negative" />
-                                                </container>
-                                            </widgets>
-                                        </section>
-                                    </box-body>
-                                </container-box>
-                            </widgets>
-                        </section>
-                    </row-col>
-                </container-row>
-            </fail-widgets>
-        </section>
+        <subscreens-panel id="ProductEvalPanel" type="tab" />
     </widgets>
 </screen>

--- a/screen/coarchy/cointernal/Products/EditProductEval.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval.xml
@@ -34,10 +34,19 @@ along with this software (see the LICENSE.md file). If not, see
         </entity-find-count>
 
         <entity-find-one entity-name="coarchy.product.ProductEvaluation" value-field="productEvaluation"/>
-        <set field="statusId" from="productEvaluation.statusId"/>
+        <if condition="!productEvaluation">
+            <if condition="isVendorView">
+                <script>sri.sendRedirectAndStopRender('/vendor')</script>
+                <else>
+                    <script>sri.sendRedirectAndStopRender('/settings/Organizations')</script>
+                </else>
+            </if>
+        </if>
+
+        <set field="statusId" from="productEvaluation?.statusId"/>
         
         <!-- safegaurd vendors from accessing product evaluation before its ready for them -->
-        <if condition="isVendorView &amp;&amp; ['PeRequirementsSelection','PeInviteVendors'].contains(productEvaluation.statusId)">
+        <if condition="isVendorView &amp;&amp; ['PeRequirementsSelection','PeInviteVendors'].contains(statusId)">
             <return error="true" message="Not allowed"/>
         </if>
 

--- a/screen/coarchy/cointernal/Products/EditProductEval/EvalHeader.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval/EvalHeader.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This software is in the public domain under CC0 1.0 Universal plus a
+Grant of Patent License.
+
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to the
+public domain worldwide. This software is distributed without any
+warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication
+along with this software (see the LICENSE.md file). If not, see
+<http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-3.xsd"
+    default-menu-include="false" standalone="true" default-menu-title="Product Evaluation Header">
+
+    <widgets>
+        <section name="FreemiumBanner" condition="partyActivationCount == 0">
+            <widgets>
+                <container type="q-banner inline-actions rounded dense" style="bg-grey-3 text-black q-mb-md">
+                    <label text="To enable all the features upgrade organization '${activeOrg.organizationName}' to Premium" type="b"/>
+                    <container type="template v-slot:action">
+                        <form-single name="UpgradeForm" transition="upgradeParty">
+                            <field name="upgrade">
+                                <default-field>
+                                    <submit text="Upgrade" type="success" confirmation="Activating will cost 1 Organization-Month Credit per month while ${activeOrg.organizationName} is upgraded. Are you sure?"/>
+                                </default-field>
+                            </field>
+                        </form-single>
+                    </container>
+                </container>
+            </widgets>
+        </section>
+
+        <section name="TitleStatusSection">
+            <widgets>
+                <container>
+                    <container-row style="q-mt-md">
+                        <row-col sm="8" xs="6">
+                            <label text="Product Evaluation on ${productEvaluation?.productName}" style="text-h4"/>
+                            <container style="q-mb-md">
+                                <label text="In the Requirements Selection step, add the requirements you want the product to be evaluated against." style="text-subtitle2 text-grey-8" condition="!isVendorView &amp;&amp; (statusId == 'PeRequirementsSelection')"/>
+                                <label text="Send invitations to product vendor representatives with a request for information about the applicability of their product to your requirement statements and process story activities." style="text-subtitle2 text-grey-8" condition="!isVendorView &amp;&amp; (statusId == 'PeInviteVendors')"/>
+                                <label text="You are waiting for vendor evaluations. You can track their responses below." style="text-subtitle2 text-grey-8" condition="!isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
+                                <label text="This Product Evaluation is awaiting your responses. Please review the statements and stories below." style="text-subtitle2 text-grey-8" condition="isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>            
+                            </container>
+                            <section name="EvalActionsSection" condition="!isVendorView">
+                                <widgets>
+                                    <link url="finalizeActivitySelection" text="Finalize Requirements Selection" confirmation="Are you sure you want to finalize the requirements selection?" btn-type="success" tooltip="Finalize Requirements Selection" parameter-map="[productEvaluationId:productEvaluationId]" condition="statusId=='PeRequirementsSelection'" />
+                                    <link url="reopenActivitySelection" text="Modify Requirements" parameter-map="[productEvaluationId:productEvaluationId]" condition="statusId=='PeInviteVendors'"/>
+                                    
+                                    <link url="finalizeVendorInvitations" text="Finalize Invitations" confirmation="Are you sure you want to finalize the vendor invitations?" btn-type="success" tooltip="Finalize Vendor Invitations" parameter-map="[productEvaluationId:productEvaluationId]" condition="statusId=='PeInviteVendors'"/>
+                                    
+                                    <link url="cancelProductEvaluation" text="Cancel Evaluation" confirmation="Are you sure you want to cancel this product evaluation?" btn-type="danger" tooltip="Cancel Product Evaluation" parameter-map="[productEvaluationId:productEvaluationId]" condition="['PeRequirementsSelection','PeInviteVendors'].contains(statusId)"/>
+                                
+                                    <section name="CompleteSection" condition="['PeAwaitingVendorResponse'].contains(statusId)">
+                                        <widgets>
+                                            <link url="completeProductEvaluation" text="Complete Evaluation" confirmation="Are you sure you want to complete this product evaluation?" btn-type="success" tooltip="Complete Product Evaluation" parameter-map="[productEvaluationId:productEvaluationId]" condition="!hasWarnings"/>
+                            
+                                            <container-dialog id="CompleteEvaluationDialog" button-text="Complete Warnings" condition="hasWarnings" type="success">
+                                                <label text="Not all Statements have internal evaluations" style="q-mx-sm text-danger" type="p" condition="!internalRespondedToAllStatements"/>
+                                                <label text="Not all Statements have vendor evaluations"  style="q-mx-sm text-danger" type="p" condition="!vendorRespondedToAllStatements"/>
+                                                <label text="Not all Process Stories have internal evaluations" style="q-mx-sm text-danger" type="p" condition="!internalRespondedToAllStories"/>
+                                                <label text="Not all Process Stories have vendor evaluations" style="q-mx-sm text-danger" type="p" condition="!vendorRespondedToAllStories" />
+                                                <link url="completeProductEvaluation" text="Complete Evaluation Anyway" link-type="hidden-form"/>
+                                            </container-dialog>
+                                        </widgets>
+                                    </section>
+                                </widgets>                
+                            </section>
+                        </row-col>
+                        <row-col sm="4" xs="6" style="float-right">
+                            <container>
+                                <label text="Status" style="text-bold" />
+                            </container>
+                            <container style="text-subtitle1">
+                                <section name="StatusInteralSection" condition="!isVendorView">
+                                    <widgets>
+                                        <label text="Requirements Selection" style="${(statusId == 'PeRequirementsSelection')?'text-primary':'text-grey-8'}" />
+                                        <label text=" / " />
+                                        
+                                        <label text="Vendor Invitations" style="${(statusId == 'PeInviteVendors')?'text-primary':'text-grey-8'}" />
+                                        <label text=" / " />
+                                        
+                                        <label text="Awaiting Responses" style="${(statusId == 'PeAwaitingVendorResponse')?'text-primary':'text-grey-8'}" />
+                                        <label text=" / " />
+                                    </widgets>
+                                    <fail-widgets>
+                                        <label text="Awaiting Response" style="${(statusId == 'PeAwaitingVendorResponse')?'text-primary':'text-grey-8'}" />
+                                        <label text=" / " />
+                                    </fail-widgets>
+                                </section>
+
+                                <label text="Complete" style="${(statusId == 'PeCompleted')?'text-primary':'text-grey-8'}" condition="statusId != 'PeCancelled'"/>                        
+                                <label text="Cancelled" style="text-negative text-bold" condition="(statusId == 'PeCancelled')"/>
+                            </container>
+                        </row-col>
+                    </container-row>
+                </container>
+            </widgets>
+        </section>
+
+        
+    </widgets>
+</screen>

--- a/screen/coarchy/cointernal/Products/EditProductEval/EvalInviteVendor.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval/EvalInviteVendor.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This software is in the public domain under CC0 1.0 Universal plus a
+Grant of Patent License.
+
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to the
+public domain worldwide. This software is distributed without any
+warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication
+along with this software (see the LICENSE.md file). If not, see
+<http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-3.xsd"
+    default-menu-include="false" standalone="true" default-menu-title="Invite Vendor">
+
+    <widgets>
+        <section name="ProductVendorInviteListSection" >          
+            <widgets>
+                <container-box>
+                    <box-header>
+                        <container-dialog id="ProductVendorInviteDialog" button-text="${(statusId=='PeAwaitingVendorResponse'?'Invite':'Add')}" button-style="float-right" condition="canInviteVendors">
+                            <container>
+                                <label text="Send invitations to product vendor representatives with a request for information about the applicability of their product to your requirement statements and process story activities." condition="!isVendorView"/>                                                   
+                                <label text="Invite your team members by adding their email address below." condition="isVendorView"/>                                                
+                            </container>
+                            <form-single name="ProductVendorInviteForm" transition="inviteVendor">
+                                <field name="productEvaluationId">
+                                    <default-field>
+                                        <hidden />
+                                    </default-field>
+                                </field>
+                                <field name="emailAddress">
+                                    <default-field>
+                                        <text-line input-type="email"/>
+                                    </default-field>
+                                </field>
+                                <field name="submit">
+                                    <default-field>
+                                        <submit text="Invite"/>
+                                    </default-field>
+                                </field>
+                                <field-layout>
+                                    <field-col-row>
+                                        <field-col sm="9">
+                                            <field-ref name="emailAddress" />
+                                        </field-col>
+                                        <field-col sm="3">
+                                            <field-ref name="submit" />
+                                        </field-col>
+                                    </field-col-row>
+                                </field-layout>
+                            </form-single>
+                        </container-dialog>
+                        <label text="Vendor Representatives" style="text-bold q-mx-md"/>
+                    </box-header>
+                    <box-body>
+                        <label text="Add as many vendor representatives you would like to evaluate the product, against these requirements. Invitations will only be sent when you click 'Finalize Invitations'." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; ['PeRequirementsSelection','PeInviteVendors'].contains(statusId)"/>
+                        <label text="You have invited the following vendors representatives to evaluate this product. You can either invite more representatives to collaborate, or let the invited representatives add more of their team members." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; ['PeAwaitingVendorResponse'].contains(statusId)"/>
+
+                        <label text="The following users are part of this evaluation. You can add team members to assist you with this evaluation by clicking on the 'Invite' button." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; ['PeAwaitingVendorResponse'].contains(statusId)"/> 
+                        
+                        <label text="The following users are part of this evaluation." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; !['PeAwaitingVendorResponse'].contains(statusId)"/>   
+
+                        <section name="VendorListSection" condition="vendorRepList">
+                            <widgets>
+                                <form-list name="ProductVendorInviteList" list="vendorRepList">
+                                    <row-actions>
+                                        <entity-find-one entity-name="mantle.party.PersonAndUserAccount" value-field="personAndAccount">
+                                            <field-map field-name="partyId" />
+                                        </entity-find-one>
+                                    </row-actions>
+                                    <field name="partyId">
+                                        <default-field>
+                                            <hidden/>
+                                        </default-field>
+                                    </field>
+                                    <field name="combinedName">
+                                        <default-field title="Representative Name">
+                                            <display text="${personAndAccount?.firstName} ${personAndAccount?.lastName}" parameter-map="personAndAccount"/>
+                                        </default-field>
+                                    </field>
+                                    <field name="emailAddress">
+                                        <default-field>
+                                            <display text="${personAndAccount.emailAddress}"/>
+                                        </default-field>
+                                    </field>
+                                    <!-- simplified status -->
+                                    <field name="statusId">
+                                        <conditional-field condition="statusId=='PepPlanned'">
+                                            <display text="Pending" style="text-grey-8"/>
+                                        </conditional-field>
+                                        <conditional-field condition="['PepInvited','PepAccepted'].contains(statusId)">
+                                            <display text="Invited" style="text-grey-8"/>
+                                        </conditional-field>
+                                        <default-field title="Status">
+                                            <!-- <display-entity entity-name="moqui.basic.StatusItem"/> -->
+                                            <label text="N/A" />
+                                        </default-field>
+                                    </field>
+                                </form-list>
+                            </widgets>
+                        </section>
+                        <section name="NoVendorListSection" condition="!vendorRepList">
+                            <widgets>
+                                <container style="text-center">
+                                    <label text="Please add at least one vendor representative to evaluate this product." style="text-bold text-negative" />
+                                </container>
+                            </widgets>
+                        </section>
+                    </box-body>
+                </container-box>
+            </widgets>
+        </section>
+    </widgets>
+</screen>

--- a/screen/coarchy/cointernal/Products/EditProductEval/EvalProcessStories.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval/EvalProcessStories.xml
@@ -45,7 +45,7 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <service-call name="coarchy.ProductEvaluationServices.include#ProductEvaluationActivity" in-map="[productEvaluationId:productEvaluationId,processStoryId:processStoryId,activityId:activityId,organizationId:activeOrgId]"/>
         </actions>
-        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[]]" save-parameters="true"/>
+        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[]]" />
     </transition>
 
     <transition name="excludeActivity" method="post">
@@ -56,9 +56,16 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <service-call name="coarchy.ProductEvaluationServices.exclude#ProductEvaluationActivity" in-map="[productEvaluationId:productEvaluationId,processStoryId:processStoryId,activityId:activityId,organizationId:activeOrgId]"/>
         </actions>
-        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[]]" save-parameters="true"/>
+        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[]]" />
     </transition>
 
+    <transition-include name="upgradeParty" location="component://coarchy/screen/coarchy/cointernal/Home.xml"/>
+    <transition-include name="inviteVendor" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="finalizeActivitySelection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="finalizeVendorInvitations" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="reopenActivitySelection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="cancelProductEvaluation" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="completeProductEvaluation" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
 
     <actions>
         <!-- find product eval -->
@@ -79,131 +86,133 @@ along with this software (see the LICENSE.md file). If not, see
         <!-- find inculded activities -->
         <service-call name="coarchy.ProductEvaluationServices.get#ProductEvaluationActivites" in-map="[productEvaluationId:productEvaluationId]" out-map="productEvalActivities" />
         <service-call name="coarchy.ProductEvaluationServices.get#ProductEvaluationResponseStats" in-map="[productEvaluationId:productEvaluationId]" out-map="context" />
-
-        <!-- find invited vendors -->
-        <entity-find entity-name="coarchy.product.ProductEvaluationParty" list="vendorRepList">
-            <date-filter />
-            <econdition field-name="productEvaluationId" />
-            <econdition field-name="roleTypeId" value="VendorRepresentative" />
-        </entity-find>
-
-        <set field="isUserInternalOrgMember" from="partyRelationshipCount &gt; 0"/>
-        <set field="isUserVendor" from="(vendorRepList*.partyId).contains(ec.user.userAccount?.partyId)"/>
-
+       
         <set field="canModifyProcessStory" from="statusId == 'PeRequirementsSelection'"/>
-        <set field="showExcludedActivities" from="statusId == 'PeRequirementsSelection'"/>
-        <set field="showReponseListButton" from="['PeAwaitingVendorResponse','PeCompleted','PeCancelled'].contains(statusId)"/>
-        <set field="showVendorRespondButton" from="isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
-        <set field="showInternalRespondButton" from="!isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
-
+        <set field="showExcludedActivities" from="statusId == 'PeRequirementsSelection'"/>       
     </actions>
 
     <widgets>
-        <container type="div">
-            <label text="Process Stories" style="text-bold" />
-            <container-dialog id="AddProcessStoryDialog" icon="add" button-text="Add Process Story to Evaluation" button-style="text-caption float-right" type="info" condition="canModifyProcessStory">
-                <form-single name="AddProcessStoryForm" transition="addProcessStory">
-                    <field name="productEvaluationId">
-                        <default-field>
-                            <hidden />
-                        </default-field>
-                    </field>
-                    <field name="processStoryIds">
-                        <default-field title="Process Stories">
-                            <drop-down allow-empty="false" allow-multiple="true">
-                                <entity-options key="${processStoryId}" text="${name}">
-                                    <entity-find entity-name="coarchy.ProcessStory">
-                                        <econdition field-name="organizationId" from="activeOrgId" />
-                                    </entity-find>
-                                </entity-options>
-                            </drop-down>
-                        </default-field>
-                    </field>
-                    <field name="submit">
-                        <default-field>
-                            <submit text="Add"/>
-                        </default-field>
-                    </field>
-                </form-single>
-            </container-dialog>
-        </container>
-        <container type="div">
-            <label text="Add the process stories you would like to be evaluated by vendors. You can include/exclude specific activities by clicking on the buttons below." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId=='PeRequirementsSelection')"/>
-            <label text="The following process story activities will be evaluated by vendors." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />
-            <label text="Evaluate the following process stories and activites." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />
-        </container>
+        <section-include name="FreemiumBanner" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalHeader.xml" />
+        <section-include name="TitleStatusSection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalHeader.xml" />
 
-        <container-row style="overflow-hidden">
-            <row-col sm="12">
-                <form-single name="FilterProcessStory" transition="filterProcessStories">
-                    <field name="productEvaluationId">
-                        <default-field>
-                            <hidden />
-                        </default-field>
-                    </field>
-                    <field name="processStoryIds">
-                        <default-field title="Filter By Process Story">
-                            <drop-down allow-empty="true" allow-multiple="true" submit-on-select="false">
-                                <!-- <entity-options>
-                                    <entity-find entity-name="coarchy.product.ProductEvaluationStoryDetail">
-                                        <econdition field-name="" />
-                                    </entity-find>
-                                </entity-options> -->
-                                <list-options list="productEvalStoryList" key="${processStoryId}" text="${name}" />
-                            </drop-down>
-                        </default-field>
-                    </field>
-                    <field name="submit">
-                        <default-field title="Filter">
-                            <submit></submit>
-                        </default-field>
-                    </field>
-                    <field-layout>
-                        <field-col-row>
-                            <field-col xs="10">
-                                <field-ref name="processStoryIds" />
-                            </field-col>
-                            <field-col xs="2">
-                                <field-ref name="submit" />
-                            </field-col>
-                        </field-col-row>
-                    </field-layout>
-                </form-single>
+        <container-row style="q-mt-lg">
+            <row-col style="${showInviteVendorsSection?'col-8':'col-12'}">        
+                <container type="div">
+                    <label text="Process Stories" style="text-bold" />
+                    <container-dialog id="AddProcessStoryDialog" icon="add" button-text="Add Process Story to Evaluation" button-style="text-caption float-right" type="info" condition="canModifyProcessStory">
+                        <form-single name="AddProcessStoryForm" transition="addProcessStory">
+                            <field name="productEvaluationId">
+                                <default-field>
+                                    <hidden />
+                                </default-field>
+                            </field>
+                            <field name="processStoryIds">
+                                <default-field title="Process Stories">
+                                    <drop-down allow-empty="false" allow-multiple="true">
+                                        <entity-options key="${processStoryId}" text="${name}">
+                                            <entity-find entity-name="coarchy.ProcessStory">
+                                                <econdition field-name="organizationId" from="activeOrgId" />
+                                            </entity-find>
+                                        </entity-options>
+                                    </drop-down>
+                                </default-field>
+                            </field>
+                            <field name="submit">
+                                <default-field>
+                                    <submit text="Add"/>
+                                </default-field>
+                            </field>
+                        </form-single>
+                    </container-dialog>
+                </container>
+
+                <container type="div">
+                    <label text="Add the process stories you would like to be evaluated by vendors. You can include/exclude specific activities by clicking on the buttons below." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId=='PeRequirementsSelection')"/>
+                    <label text="The following process story activities will be evaluated by vendors." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />
+                    <label text="Evaluate the following process stories and activites." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />
+                </container>
+
+                <container-row style="overflow-hidden">
+                    <row-col sm="12">
+                        <form-single name="FilterProcessStory" transition="filterProcessStories">
+                            <field name="productEvaluationId">
+                                <default-field>
+                                    <hidden />
+                                </default-field>
+                            </field>
+                            <field name="processStoryIds">
+                                <default-field title="Filter By Process Story">
+                                    <drop-down allow-empty="true" allow-multiple="true" submit-on-select="false">
+                                        <!-- <entity-options>
+                                            <entity-find entity-name="coarchy.product.ProductEvaluationStoryDetail">
+                                                <econdition field-name="" />
+                                            </entity-find>
+                                        </entity-options> -->
+                                        <list-options list="productEvalStoryList" key="${processStoryId}" text="${name}" />
+                                    </drop-down>
+                                </default-field>
+                            </field>
+                            <field name="submit">
+                                <default-field title="Filter">
+                                    <submit></submit>
+                                </default-field>
+                            </field>
+                            <field-layout>
+                                <field-col-row>
+                                    <field-col xs="10">
+                                        <field-ref name="processStoryIds" />
+                                    </field-col>
+                                    <field-col xs="2">
+                                        <field-ref name="submit" />
+                                    </field-col>
+                                </field-col-row>
+                            </field-layout>
+                        </form-single>
+                    </row-col>
+                    <row-col sm="12">
+                        <label text="Showing ${filterProductEvalStoryList.size()} of ${processStoryIdList.size()} process stories" style="text-bold" />
+
+                        <section-iterate name="ProcessStorySection" list="filterProductEvalStoryList" entry="filterProductEvalStory">
+                            <actions>
+                                <set field="processStoryId" from="filterProductEvalStory.processStoryId"/>
+
+                                <!-- defaults to true for now -->
+                                <set field="showSubstories" value="Y"/>
+                                
+                                <!-- find activities in process stories -->
+                                <service-call name="coarchy.ProductEvaluationServices.find#ProcessStoryActivityList" in-map="[productEvaluationId:productEvaluationId,processStoryId:processStoryId,
+                                    showSubstories:showSubstories,organizationId:productEvaluation.organizationId]" out-map="context"/>
+
+                                <set field="hasSubstories" from="processStoryActivityList*.detailProcessStoryId.any{ it != null }"/>
+                                <set field="showSubstoriesActual" from="showSubstories=='Y' &amp;&amp; hasSubstories"/>
+                            </actions>
+                            <widgets>
+                                <container-box>
+                                    <box-header>
+                                        <container type="span" style="q-mr-xs">
+                                            <link url="removeProcessStory" parameter-map="[processStoryId:processStoryId]" text="Remove" style="text-caption text-negative" condition="canModifyProcessStory"/>
+                                        </container>
+                                        <label text="Process Story (${filterProductEvalStory_index+1} of ${processStoryIdList.size()})" style="q-pr-sm"/>
+                                        <label text="${filterProductEvalStory?.name?' - '+filterProductEvalStory.name:''}" style="text-bold"/>
+                                    </box-header>
+                                    <box-body>
+                                        <render-mode>
+                                            <text type="html,vuet,qvt" location="component://coarchy/template/ProcessStoryEvalOutline.html.ftl"/>
+                                        </render-mode>
+                                    </box-body>
+                                </container-box>
+                            </widgets>
+                        </section-iterate>
+                    </row-col>
+                </container-row>
             </row-col>
-            <row-col sm="12">
-                <label text="Showing ${filterProductEvalStoryList.size()} of ${processStoryIdList.size()} process stories" style="text-bold" />
-
-                <section-iterate name="ProcessStorySection" list="filterProductEvalStoryList" entry="filterProductEvalStory">
-                    <actions>
-                        <set field="processStoryId" from="filterProductEvalStory.processStoryId"/>
-
-                        <!-- defaults to true for now -->
-                        <set field="showSubstories" value="Y"/>
-                        
-                        <!-- find activities in process stories -->
-                        <service-call name="coarchy.ProductEvaluationServices.find#ProcessStoryActivityList" in-map="[productEvaluationId:productEvaluationId,processStoryId:processStoryId,
-                            showSubstories:showSubstories,organizationId:productEvaluation.organizationId]" out-map="context"/>
-
-                        <set field="hasSubstories" from="processStoryActivityList*.detailProcessStoryId.any{ it != null }"/>
-                        <set field="showSubstoriesActual" from="showSubstories=='Y' &amp;&amp; hasSubstories"/>
-                    </actions>
+            
+            <row-col style="${showInviteVendorsSection?'col-4':'hidden'}">
+                <section name="ProductVendorInviteContainerSection" condition="showInviteVendorsSection">
                     <widgets>
-                        <container-box>
-                            <box-header>
-                                <container type="span" style="q-mr-xs">
-                                    <link url="removeProcessStory" parameter-map="[processStoryId:processStoryId]" text="Remove" style="text-caption text-negative" condition="canModifyProcessStory"/>
-                                </container>
-                                <label text="Process Story (${filterProductEvalStory_index+1} of ${processStoryIdList.size()})" style="q-pr-sm"/>
-                                <label text="${filterProductEvalStory?.name?' - '+filterProductEvalStory.name:''}" style="text-bold"/>
-                            </box-header>
-                            <box-body>
-                                <render-mode>
-                                    <text type="html,vuet,qvt" location="component://coarchy/template/ProcessStoryEvalOutline.html.ftl"/>
-                                </render-mode>
-                            </box-body>
-                        </container-box>
+                        <section-include name="ProductVendorInviteListSection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalInviteVendor.xml" />
                     </widgets>
-                </section-iterate>
+                </section>
             </row-col>
         </container-row>
     </widgets>

--- a/screen/coarchy/cointernal/Products/EditProductEval/EvalProcessStories.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval/EvalProcessStories.xml
@@ -16,6 +16,7 @@ along with this software (see the LICENSE.md file). If not, see
 
     <parameter name="productEvaluationId" required="true"/>
     <parameter name="processStoryIds" />
+    <parameter name="anchor" />
 
     <transition name="filterProcessStories">
         <default-response url="." parameter-map="[productEvaluationId:productEvaluationId,processStoryIds:processStoryIds]"/>
@@ -45,7 +46,7 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <service-call name="coarchy.ProductEvaluationServices.include#ProductEvaluationActivity" in-map="[productEvaluationId:productEvaluationId,processStoryId:processStoryId,activityId:activityId,organizationId:activeOrgId]"/>
         </actions>
-        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[]]" />
+        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[],anchor:activityId]" />
     </transition>
 
     <transition name="excludeActivity" method="post">
@@ -56,7 +57,7 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <service-call name="coarchy.ProductEvaluationServices.exclude#ProductEvaluationActivity" in-map="[productEvaluationId:productEvaluationId,processStoryId:processStoryId,activityId:activityId,organizationId:activeOrgId]"/>
         </actions>
-        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[]]" />
+        <default-response url="/coapp/Products/EditProductEval/EvalProcessStories" parameter-map="[productEvaluationId:productEvaluationId, processStoryIds:processStoryIds?:[],anchor:activityId]" />
     </transition>
 
     <transition-include name="upgradeParty" location="component://coarchy/screen/coarchy/cointernal/Home.xml"/>
@@ -215,5 +216,23 @@ along with this software (see the LICENSE.md file). If not, see
                 </section>
             </row-col>
         </container-row>
+
+        <text type="html,vuet,qvt"><![CDATA[
+            <script>
+                let anchorId = '${anchor!''}';
+                if (anchorId){
+                    const elements = $('#'+anchorId)
+                    if (elements.length){
+                        const element = elements[0];
+                        const topPos = element.getBoundingClientRect().top + window.pageYOffset
+
+                        window.scrollTo({
+                        top: topPos - 60, Account for q-header (~58px in height)
+                        behavior: 'smooth' // smooth scroll
+                        })
+                    }
+                }
+            </script>
+        ]]></text>
     </widgets>
 </screen>

--- a/screen/coarchy/cointernal/Products/EditProductEval/EvalResponse.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval/EvalResponse.xml
@@ -26,7 +26,7 @@ along with this software (see the LICENSE.md file). If not, see
     <parameter name="orderByField"/>
 
     <transition name="addEvalResponse">    
-        <service-call name="coarchy.ProductEvaluationServices.add#ProductEvaluationResponse" in-map="[productEvaluationId:productEvaluationId, activityId:activityId, statementId:statementId, implementationStatusEnumId:implementationStatusEnumId, rating:rating, comments:comments,organizationId:activeOrgId,  _openDialog:_openDialog]"/>
+        <service-call name="coarchy.ProductEvaluationServices.add#ProductEvaluationResponse" in-map="[productEvaluationId:productEvaluationId, activityId:activityId, statementId:statementId, implementationStatusEnumId:implementationStatusEnumId, rating:rating, comments:comments,organizationId:activeOrgId, isVendor:isVendor,  _openDialog:_openDialog]"/>
         <conditional-response url="../EvalProcessStories" parameter-map="[_openDialog:_openDialog, productEvaluationId:productEvaluationId, activityId:null,statementId:null, processStoryIds:processStoryIds]">
             <condition>
                 <expression>activityId</expression>
@@ -159,7 +159,13 @@ along with this software (see the LICENSE.md file). If not, see
                     <hidden/>
                 </default-field>
             </field>
-             <field name="processStoryIds" from="processStoryIds">
+            <field name="processStoryIds" from="processStoryIds">
+                <!-- filter pass through -->
+                <default-field>
+                    <hidden/>
+                </default-field>
+            </field>
+            <field name="isVendor" from="isVendorView">
                 <!-- filter pass through -->
                 <default-field>
                     <hidden/>
@@ -167,7 +173,7 @@ along with this software (see the LICENSE.md file). If not, see
             </field>
             <field name="implementationStatusEnumId">
                 <default-field title="Implementation Status">
-                    <drop-down submit-on-select="false" allow-empty="false" allow-multiple="false">
+                    <drop-down submit-on-select="false" allow-empty="false" allow-multiple="false" no-current-selected-key="IsPartialOverlap">
                         <entity-options>
                             <entity-find entity-name="moqui.basic.Enumeration">
                                 <econdition field-name="enumTypeId" value="ImplementationStatus" />

--- a/screen/coarchy/cointernal/Products/EditProductEval/EvalStatements.xml
+++ b/screen/coarchy/cointernal/Products/EditProductEval/EvalStatements.xml
@@ -43,6 +43,14 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response url="." parameter-map="[productEvaluationId:productEvaluationId,typeEnumIds:typeEnumIds]"/>
     </transition>
 
+    <transition-include name="upgradeParty" location="component://coarchy/screen/coarchy/cointernal/Home.xml"/>
+    <transition-include name="inviteVendor" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="finalizeActivitySelection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="finalizeVendorInvitations" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="reopenActivitySelection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="cancelProductEvaluation" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+    <transition-include name="completeProductEvaluation" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval.xml"/>
+
     <actions>
         <!-- find product eval -->
         <entity-find-one entity-name="coarchy.product.ProductEvaluationAndProduct" value-field="productEvaluation"/>
@@ -53,134 +61,145 @@ along with this software (see the LICENSE.md file). If not, see
         <service-call name="coarchy.ProductEvaluationServices.get#ProductEvaluationResponseStats" in-map="[productEvaluationId:productEvaluationId]" out-map="context" />
 
         <set field="canModifyStatements" from="statusId == 'PeRequirementsSelection'"/>
-        <set field="showReponseListButton" from="['PeAwaitingVendorResponse','PeCompleted','PeCancelled'].contains(statusId)"/>
-        <set field="showVendorRespondButton" from="isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
-        <set field="showInternalRespondButton" from="!isVendorView &amp;&amp; (statusId == 'PeAwaitingVendorResponse')"/>
     </actions>
 
     <widgets>
-        <container-row >
-            <row-col sm="12">
-                <label text="Statements" style="text-bold" type="div"/>
-                <container type="div">
-                    <label text="By default, all statements in your organization will be evaluated by the vendors. You can choose to Include/Exclude them by clicking on the buttons below." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId=='PeRequirementsSelection')"/>
-                    <label text="The following statements will be evaluated by vendors." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />
-                    <label text="Evaluate the following statements." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />                        
-                </container>
+        <section-include name="FreemiumBanner" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalHeader.xml" />
+        <section-include name="TitleStatusSection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalHeader.xml" />
+
+        <container-row style="q-mt-lg">
+            <row-col style="${showInviteVendorsSection?'col-8':'col-12'}">      
+                <container-row >
+                    <row-col sm="12">
+                        <label text="Statements" style="text-bold" type="div"/>
+                        <container type="div">
+                            <label text="By default, all statements in your organization will be evaluated by the vendors. You can choose to Include/Exclude them by clicking on the buttons below." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId=='PeRequirementsSelection')"/>
+                            <label text="The following statements will be evaluated by vendors." style="text-caption text-grey-8" condition="!isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />
+                            <label text="Evaluate the following statements." style="text-caption text-grey-8" condition="isVendorView &amp;&amp; (statusId!='PeRequirementsSelection')" />                        
+                        </container>
+                    </row-col>
+                </container-row>
+                <container-row style="overflow-hidden">
+                    <row-col sm="12">
+                        <form-single name="FilterStatementType" transition="filterStatementType">
+                            <field name="productEvaluationId">
+                                <default-field>
+                                    <hidden />
+                                </default-field>
+                            </field>
+                            <field name="typeEnumIds">
+                                <default-field title="Filter By Statement Type">
+                                    <drop-down allow-empty="true" allow-multiple="true">
+                                        <entity-options>
+                                            <entity-find entity-name="moqui.basic.Enumeration">
+                                                <econdition field-name="enumTypeId" value="ValueType" />
+                                            </entity-find>
+                                        </entity-options>
+                                    </drop-down>
+                                </default-field>
+                            </field>
+                            <field name="submit">
+                                <default-field title="Filter">
+                                    <submit></submit>
+                                </default-field>
+                            </field>
+                            <field-layout>
+                                <field-col-row>
+                                    <field-col xs="10">
+                                        <field-ref name="typeEnumIds" />
+                                    </field-col>
+                                    <field-col xs="2">
+                                        <field-ref name="submit" />
+                                    </field-col>
+                                </field-col-row>
+                            </field-layout>
+                        </form-single>
+                    </row-col>
+                </container-row>
+                <container-row style="overflow-hidden">
+                    <row-col sm="12">
+                        <form-list name="EvalStatementsList" list="allValueStatementList">
+                            <entity-find entity-name="coarchy.ValueStatement" list="allValueStatementList">
+                                <search-form-inputs default-order-by="typeEnumId" />
+                                <econditions combine="or">
+                                    <econdition field-name="valueStatementId" operator="in" from="productEvalStatements.valueStatementIds" />
+                                    <econditions combine="and">
+                                        <econdition field-name="replacedByValueStatementId" operator="is-null" />
+                                        <econdition field-name="disabled" value="N" or-null="true" />
+                                    </econditions>
+                                </econditions>
+                                <econdition field-name="typeEnumId" operator="in" from="typeEnumIds" ignore-if-empty="true" />
+                                <econdition field-name="organizationId" operator="in" from="productEvaluation.organizationId" />
+                                <econdition field-name="valueStatementId" operator="in" from="productEvalStatements.valueStatementIds" ignore="canModifyStatements" />
+                            </entity-find>
+                            <row-actions>
+                                <set field="isStatementIncluded" from="productEvalStatements.valueStatementIds.contains(valueStatementId)"/>
+                                <set field="responseCount" from="vendorResponseByStatement[valueStatementId]"/>
+                                <set field="internalResponseCount" from="internalResponseByStatement[valueStatementId]"/>
+                                <set field="vendorResponseComplete" from="responseCount &gt; 0"/>
+                                <set field="internalResponseComplete" from="internalResponseCount &gt; 0"/>
+                            </row-actions>
+                            <field name="toggleInclusion">
+                                <conditional-field condition="canModifyStatements &amp;&amp; isStatementIncluded" title="">
+                                    <link url="excludeStatement" text="Included" btn-type="success" condition="isStatementIncluded" icon="fa fa-check" style="text-caption" parameter-map="[productEvaluationId:productEvaluationId, statementId:valueStatementId, typeEnumIds:typeEnumIds]"/>
+                                </conditional-field>
+                                <conditional-field condition="canModifyStatements &amp;&amp; !isStatementIncluded" title="">
+                                    <link url="includeStatement" text="Excluded" btn-type="danger" condition="!isStatementIncluded" icon="fa fa-close" style="text-caption" parameter-map="[productEvaluationId:productEvaluationId, statementId:valueStatementId, typeEnumIds:typeEnumIds]"/>
+                                </conditional-field>
+                                <default-field title="">
+                                    <hidden/>
+                                </default-field>
+                            </field>
+                            <field name="valueStatementId">
+                                <default-field >
+                                    <hidden/>
+                                </default-field>
+                            </field>
+                            <field name="productEvaluationId" from="productEvaluationId">
+                                <default-field>
+                                    <hidden />
+                                </default-field>
+                            </field>
+                            <field name="value">
+                                <conditional-field title="Statement" condition="isStatementIncluded">
+                                    <render-mode >
+                                        <text>${value}</text>
+                                    </render-mode>
+                                </conditional-field>
+                                <conditional-field title="Statement" condition="!isStatementIncluded">
+                                    <render-mode >
+                                        <text><![CDATA[<s class="text-grey-8">${value}</s>]]></text>
+                                    </render-mode>
+                                </conditional-field>
+                            </field>
+                            <field name="typeEnumId">
+                                <default-field title="Type">
+                                    <display-entity entity-name="moqui.basic.Enumeration"/>
+                                </default-field>
+                            </field>                   
+                            <field name="actions">  
+                                <conditional-field condition="isVendorView" title="">
+                                    <dynamic-dialog id="StatementResponseDialog" title="Evaluate Statement" button-text="${vendorResponseComplete?'Update':'Evaluate'}" transition="../EvalResponse" parameter-map="[valueStatementId:valueStatementId,typeEnumIds:typeEnumIds]" button-style="text-caption" type="${vendorResponseComplete?'success':'danger'}" condition="showVendorRespondButton"/>
+                                    <dynamic-dialog id="StatementResponseListDialog" title="Statement Evaluations" button-text="View (${responseCount})" transition="../EvalList" parameter-map="[valueStatementId:valueStatementId]" button-style="text-caption" condition="showReponseListButton"/>
+                                </conditional-field> 
+                                <conditional-field condition="!isVendorView" title="">
+                                    <dynamic-dialog id="StatementResponseDialog" title="Add Internal Evaluation on Statement" button-text="${internalResponseComplete?'Update Internal':'Internal Evaluation'}" transition="../EvalResponse" parameter-map="[valueStatementId:valueStatementId,typeEnumIds:typeEnumIds]" button-style="text-caption" type="${internalResponseComplete?'success':'danger'}" condition="showInternalRespondButton"/>
+                                    <dynamic-dialog id="StatementResponseListDialog" title="Statement Evaluations" button-text="View (${responseCount+internalResponseCount})" transition="../EvalList" parameter-map="[valueStatementId:valueStatementId]" button-style="text-caption" condition="showReponseListButton"/>
+                                </conditional-field>                 
+                                <default-field title="">
+                                    <hidden />
+                                </default-field>
+                            </field>
+                        </form-list>
+                    </row-col>
+                </container-row>
             </row-col>
-        </container-row>
-        <container-row style="overflow-hidden">
-            <row-col sm="12">
-                <form-single name="FilterStatementType" transition="filterStatementType">
-                    <field name="productEvaluationId">
-                        <default-field>
-                            <hidden />
-                        </default-field>
-                    </field>
-                    <field name="typeEnumIds">
-                        <default-field title="Filter By Statement Type">
-                            <drop-down allow-empty="true" allow-multiple="true">
-                                <entity-options>
-                                    <entity-find entity-name="moqui.basic.Enumeration">
-                                        <econdition field-name="enumTypeId" value="ValueType" />
-                                    </entity-find>
-                                </entity-options>
-                            </drop-down>
-                        </default-field>
-                    </field>
-                    <field name="submit">
-                        <default-field title="Filter">
-                            <submit></submit>
-                        </default-field>
-                    </field>
-                    <field-layout>
-                        <field-col-row>
-                            <field-col xs="10">
-                                <field-ref name="typeEnumIds" />
-                            </field-col>
-                            <field-col xs="2">
-                                <field-ref name="submit" />
-                            </field-col>
-                        </field-col-row>
-                    </field-layout>
-                </form-single>
-            </row-col>
-        </container-row>
-        <container-row style="overflow-hidden">
-            <row-col sm="12">
-                <form-list name="EvalStatementsList" list="allValueStatementList">
-                    <entity-find entity-name="coarchy.ValueStatement" list="allValueStatementList">
-                        <search-form-inputs default-order-by="typeEnumId" />
-                        <econditions combine="or">
-                            <econdition field-name="valueStatementId" operator="in" from="productEvalStatements.valueStatementIds" />
-                            <econditions combine="and">
-                                <econdition field-name="replacedByValueStatementId" operator="is-null" />
-                                <econdition field-name="disabled" value="N" or-null="true" />
-                            </econditions>
-                        </econditions>
-                        <econdition field-name="typeEnumId" operator="in" from="typeEnumIds" ignore-if-empty="true" />
-                        <econdition field-name="organizationId" operator="in" from="productEvaluation.organizationId" />
-                        <econdition field-name="valueStatementId" operator="in" from="productEvalStatements.valueStatementIds" ignore="canModifyStatements" />
-                    </entity-find>
-                    <row-actions>
-                        <set field="isStatementIncluded" from="productEvalStatements.valueStatementIds.contains(valueStatementId)"/>
-                        <set field="responseCount" from="vendorResponseByStatement[valueStatementId]"/>
-                        <set field="internalResponseCount" from="internalResponseByStatement[valueStatementId]"/>
-                        <set field="vendorResponseComplete" from="responseCount &gt; 0"/>
-                        <set field="internalResponseComplete" from="internalResponseCount &gt; 0"/>
-                    </row-actions>
-                    <field name="toggleInclusion">
-                        <conditional-field condition="canModifyStatements &amp;&amp; isStatementIncluded" title="">
-                            <link url="excludeStatement" text="Included" btn-type="success" condition="isStatementIncluded" icon="fa fa-check" style="text-caption" parameter-map="[productEvaluationId:productEvaluationId, statementId:valueStatementId, typeEnumIds:typeEnumIds]"/>
-                        </conditional-field>
-                        <conditional-field condition="canModifyStatements &amp;&amp; !isStatementIncluded" title="">
-                            <link url="includeStatement" text="Excluded" btn-type="danger" condition="!isStatementIncluded" icon="fa fa-close" style="text-caption" parameter-map="[productEvaluationId:productEvaluationId, statementId:valueStatementId, typeEnumIds:typeEnumIds]"/>
-                        </conditional-field>
-                        <default-field title="">
-                            <hidden/>
-                        </default-field>
-                    </field>
-                    <field name="valueStatementId">
-                        <default-field >
-                            <hidden/>
-                        </default-field>
-                    </field>
-                    <field name="productEvaluationId" from="productEvaluationId">
-                        <default-field>
-                            <hidden />
-                        </default-field>
-                    </field>
-                    <field name="value">
-                        <conditional-field title="Statement" condition="isStatementIncluded">
-                            <render-mode >
-                                <text>${value}</text>
-                            </render-mode>
-                        </conditional-field>
-                        <conditional-field title="Statement" condition="!isStatementIncluded">
-                            <render-mode >
-                                <text><![CDATA[<s class="text-grey-8">${value}</s>]]></text>
-                            </render-mode>
-                        </conditional-field>
-                    </field>
-                    <field name="typeEnumId">
-                        <default-field title="Type">
-                            <display-entity entity-name="moqui.basic.Enumeration"/>
-                        </default-field>
-                    </field>                   
-                    <field name="actions">  
-                        <conditional-field condition="isVendorView" title="">
-                            <dynamic-dialog id="StatementResponseDialog" title="Evaluate Statement" button-text="${vendorResponseComplete?'Update':'Evaluate'}" transition="../EvalResponse" parameter-map="[valueStatementId:valueStatementId,typeEnumIds:typeEnumIds]" button-style="text-caption" type="${vendorResponseComplete?'success':'danger'}" condition="showVendorRespondButton"/>
-                            <dynamic-dialog id="StatementResponseListDialog" title="Statement Evaluations" button-text="View (${responseCount})" transition="../EvalList" parameter-map="[valueStatementId:valueStatementId]" button-style="text-caption" condition="showReponseListButton"/>
-                        </conditional-field> 
-                        <conditional-field condition="!isVendorView" title="">
-                            <dynamic-dialog id="StatementResponseDialog" title="Add Internal Evaluation on Statement" button-text="${internalResponseComplete?'Update Internal':'Internal Evaluation'}" transition="../EvalResponse" parameter-map="[valueStatementId:valueStatementId,typeEnumIds:typeEnumIds]" button-style="text-caption" type="${internalResponseComplete?'success':'danger'}" condition="showInternalRespondButton"/>
-                            <dynamic-dialog id="StatementResponseListDialog" title="Statement Evaluations" button-text="View (${responseCount+internalResponseCount})" transition="../EvalList" parameter-map="[valueStatementId:valueStatementId]" button-style="text-caption" condition="showReponseListButton"/>
-                        </conditional-field>                 
-                        <default-field title="">
-                            <hidden />
-                        </default-field>
-                    </field>
-                </form-list>
+            <row-col style="${showInviteVendorsSection?'col-4':'hidden'}">
+                <section name="ProductVendorInviteContainerSection" condition="showInviteVendorsSection">
+                    <widgets>
+                        <section-include name="ProductVendorInviteListSection" location="component://coarchy/screen/coarchy/cointernal/Products/EditProductEval/EvalInviteVendor.xml"  />
+                    </widgets>
+                </section>
             </row-col>
         </container-row>
     </widgets>

--- a/service/coarchy/ProductEvaluationServices.xml
+++ b/service/coarchy/ProductEvaluationServices.xml
@@ -582,6 +582,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="implementationStatusEnumId" required="true" />
             <parameter name="rating" type="Integer" />
             <parameter name="comments" />
+            <parameter name="isVendor" type="Boolean" />
         </in-parameters>
         <actions>
             <entity-find-one entity-name="coarchy.product.ProductEvaluation"
@@ -600,8 +601,20 @@ along with this software (see the LICENSE.md file). If not, see
                 <econdition field-name="fromPartyId" from="ec.user.userAccount.partyId" />
                 <econdition field-name="toPartyId" from="productEvaluation.organizationId" />
             </entity-find-count>
-            <set field="isUserOrgMember" from="partyRelationshipCount > 0" />
+            
+            <entity-find-count entity-name="mantle.party.PartyRelationship"
+                count-field="vendorRelationshipCount">
+                <date-filter />
+                <econdition field-name="relationshipTypeEnumId" value="PrtVendorRepresentative" />
+                <econdition field-name="toRoleTypeId" value="VendorRepresentative" />
+                <econdition field-name="fromPartyId" from="ec.user.userAccount.partyId" />
+                <econdition field-name="toPartyId" from="productEvaluation.organizationId" />
+            </entity-find-count>
 
+            <if condition="!partyRelationshipCount &amp;&amp; ! vendorRelationshipCount">
+                <return error="true" message="You are not allowed to perform this action." />
+            </if>
+            <set field="isResponseInternal" from="(isVendor &amp;&amp; vendorRelationshipCount>0)?false:(partyRelationshipCount>0)" />
             <set field="lastEditedByUserId" from="ec.user.userId" />
 
             <!-- find existing response, if exists, update, otherwise create -->
@@ -609,16 +622,16 @@ along with this software (see the LICENSE.md file). If not, see
                 list="productEvalResponseList">
                 <econdition field-name="productEvaluationId" />
                 <econdition field-name="evaluationByEnumId" value="EbInternal"
-                    ignore="!isUserOrgMember" />
+                    ignore="!isResponseInternal" />
                 <econdition field-name="evaluationByEnumId" value="EbVendor"
-                    ignore="isUserOrgMember" />
+                    ignore="isResponseInternal" />
                 <econdition field-name="activityId" ignore="!activityId" />
                 <econdition field-name="statementId" ignore="!statementId" />
             </entity-find>
 
             <if condition="!productEvalResponseList">
                 <service-call name="create#coarchy.product.ProductEvaluationResponse"
-                    in-map="[productEvaluationId:productEvaluationId, activityId:activityId, statementId:statementId, implementationStatusEnumId:implementationStatusEnumId, rating:rating, comments:comments, lastEditedByUserId: lastEditedByUserId, evaluationByEnumId: isUserOrgMember?'EbInternal':'EbVendor',organizationId:organizationId]" />
+                    in-map="[productEvaluationId:productEvaluationId, activityId:activityId, statementId:statementId, implementationStatusEnumId:implementationStatusEnumId, rating:rating, comments:comments, lastEditedByUserId: lastEditedByUserId, evaluationByEnumId: isResponseInternal?'EbInternal':'EbVendor',organizationId:organizationId]" />
                 <else>
                     <set field="productEvalResponse" from="productEvalResponseList[0]" />
                     <service-call name="update#coarchy.product.ProductEvaluationResponse"
@@ -1118,6 +1131,16 @@ along with this software (see the LICENSE.md file). If not, see
                 </then>
                 <else>
                     <set field="newUser" from="existingUaList?.getFirst()" />
+                    <entity-find entity-name="moqui.security.UserGroupMember" list="vendorGroupMemberList">
+                        <date-filter />
+                        <econdition field-name="userGroupId" value="COARCHY_VENDORS" />
+                        <econdition field-name="userId" from="newUser.userId" />
+                    </entity-find>
+                    <if condition="!vendorGroupMemberList">
+                        <service-call name="create#moqui.security.UserGroupMember"
+                        in-map="[userGroupId:'COARCHY_VENDORS',
+                            userId:newUser.userId, fromDate:ec.user.nowTimestamp]" />
+                    </if>
                 </else>
             </if>
             <set field="newPartyId" from="newUser.partyId" />

--- a/template/ProcessStoryEvalOutline.html.ftl
+++ b/template/ProcessStoryEvalOutline.html.ftl
@@ -69,7 +69,7 @@
         <#list processStoryActivity.detailProcessStoryActivityList! as processStoryActivity>
             <#assign isActivityIncluded = productEvalActivities.activityIds?seq_contains(processStoryActivity.activityId)/>
             <#if !isActivityIncluded && !showExcludedActivities><#continue/></#if>
-            <li>
+            <li id="${processStoryActivity.activityId}">
             <@activityResponseList processStoryActivity />
             <@evaluateActivityButton processStoryActivity />
             <@toggleActivityInclusion processStoryActivity />
@@ -88,7 +88,7 @@
 <#list processStoryActivityList! as processStoryActivity>
     <#assign isActivityIncluded = productEvalActivities.activityIds?seq_contains(processStoryActivity.activityId)/>
     <#if !isActivityIncluded && !showExcludedActivities><#continue/></#if>
-    <#if processStoryActivity.action!?has_content><li></#if>
+    <#if processStoryActivity.action!?has_content><li id="${processStoryActivity.activityId}"></#if>
     <@activityResponseList processStoryActivity />
     <@evaluateActivityButton processStoryActivity />
     <@toggleActivityInclusion processStoryActivity />


### PR DESCRIPTION
Changes: 
- Added scroll-to anchor in EvalProcessStories screen
- Auto redirect if vendor switches organization when viewing an evaluation
- Restructure EditProductEval screen, Use EvalProcessStories and EvalStatements as full screens
- Fix eval response user being both internal and vendor. 
- Default to Partial Overlap with a 5 rating in an evaluation response. 
- Ensure any invited user is given proper vendor app permissions.
- Remove ProductEval ID from EditEval screen